### PR TITLE
Remove content-length header when proxy is used

### DIFF
--- a/lib/dev-proxy.js
+++ b/lib/dev-proxy.js
@@ -13,14 +13,48 @@ module.exports = function (host, ports, options) {
 
     var proxyOptions = options.proxy || options.website;
 
-    var getSnippet = function (hostIp, socketIoPort, scriptPort) {
-        return messages.scriptTags(hostIp, socketIoPort, scriptPort);
+    var getSnippet = function () {
+        var snp = messages.scriptTags(host, ports[0], ports[1]);
+        return snp;
     };
+
+    var excludeList = ['.woff', '.js', '.css', '.ico'];
+
+    function bodyExists(body) {
+        if (!body) return false;
+        return (~body.lastIndexOf("</body>"));
+    }
+
+    function snippetExists(body) {
+        if (!body) return true;
+        return (~body.lastIndexOf(getSnippet()));
+    }
+
+    function acceptsHtmlExplicit(req) {
+        var accept = req.headers["accept"];
+        if (!accept) return false;
+        return (~accept.indexOf("html"));
+    }
+
+    function isExcluded(req) {
+        var url = req.url;
+        var excluded = false;
+        if (!url) return true;
+        excludeList.forEach(function(exclude) {
+            if (~url.indexOf(exclude)) {
+                excluded = true;
+            }
+        });
+        return excluded;
+    }
 
     //
     // Set up a proxy
     //
     var server = httpProxy.createServer(function (req, res, proxy) {
+        var writeHead = res.writeHead;
+        var write = res.write;
+        var end = res.end;
 
         //
         // Put your custom server logic here
@@ -33,60 +67,51 @@ module.exports = function (host, ports, options) {
             });
         };
 
-        // For every request, we wrap the 'write' function of the
-        // server, so we can inject the snippet if required.
-        var write = res.write;
 
-        res.write = function (string, encoding) {
+        if (!acceptsHtmlExplicit(req) || isExcluded(req)) {
+            return next();
+        }
 
-            var body = string instanceof Buffer ? string.toString() : string;
-
-            // Is it not html
-            if (!/<!doctype[^>]*>/i.test(body)) {
-                return write.call(res, string, encoding);
+        res.writeHead = function(statusCode, reasonPhrase, headers) {
+            // Prevents sending headers before our patching iif status 200
+            if (statusCode !== 200) {
+                writeHead.apply(res, arguments);
             }
+        };
 
-            // Try to inject script
-            body = body.replace(/<\/body>/, function (w) {
-                return messages.scriptTags(host, ports[0], ports[1]) + w;
-            });
+        res.push = function(chunk) {
+            res.data = (res.data || '') + chunk;
+        };
 
-            if (string instanceof Buffer) {
-                string = new Buffer(body);
-            } else {
-                string = body;
+        res.inject = res.write = function(string, encoding) {
+            res.write = write;
+            if (string !== undefined) {
+                var body = string instanceof Buffer ? string.toString(encoding) : string;
+                if ((bodyExists(body) || bodyExists(res.data)) && !snippetExists(body) && (!res.data || !snippetExists(res.data))) {
+                    res.push(body.replace(/<\/body>/, function(w) {
+                        return getSnippet() + w;
+                    }));
+                    return true;
+                } else {
+                    return res.write(string, encoding);
+                }
             }
+            return true;
+        };
 
-            if (!this.headerSent) {
-                this.setHeader('content-length', Buffer.byteLength(body));
-                this._implicitHeader();
+        res.end = function(string, encoding) {
+            res.writeHead = writeHead;
+            res.end = end;
+            var result = res.inject(string, encoding);
+            if (!result) return res.end(string, encoding);
+            if (res.data !== undefined && !res._header) {
+                res.setHeader('content-length', Buffer.byteLength(res.data, encoding));
             }
-
-            write.call(res, string, encoding);
+            res.end(res.data, encoding);
         };
 
         next();
 
     }).listen(ports[2]);
-
-    // node-http-proxy exposes the proxy so we can hook event handlers
-    // now, instead of on every request, which would be catastrophic
-    server.proxy.on('proxyResponse', function (req, res, response) {
-        // If the content-length has been specified, remove it. This
-        // allows to inject the snippet without truncating issues.
-
-        // NOTE: The drawback of this workaround is that for HTTP/1.0
-        // requests, it could cause issues (because RFC says we should
-        // send the content-length). In other words, this solution is OK
-        // if you only need to provide support for HTTP/1.1, in which
-        // case the "transfer-encoding: chunked" header is sent by http
-        // proxy server anyway (and AFAIK we cannot prevent that easily)
-        // and RFC says we shouldn't send the content-length in these
-        // cases.
-        if (response.headers.hasOwnProperty("content-length")) {
-            delete response.headers["content-length"];
-        }
-    });
-
 
 };


### PR DESCRIPTION
Otherwise the content-length won't be correct after injecting the snippet,
causing the snippet to be truncated (unless you add enough padding at the end
of the original html file).
