### PR TITLE
Fixes #41 by checking x-requested-with header before triggering navigation

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -40,8 +40,12 @@ var utils = {
 
         return function (req, res, next) {
 
-            if (options && options.ghostMode && options.ghostMode.links) {
+            var headers = req.headers || {};
+            if (headers["x-requested-with"] !== undefined && headers["x-requested-with"] === "XMLHttpRequest") {
+                return next();
+            }
 
+            if (options && options.ghostMode && options.ghostMode.links) {
                 if (!snippetUtils.isExcluded(req) && req.method === "GET") {
 
                     var clients = io.sockets.clients();
@@ -65,6 +69,7 @@ var utils = {
                     }
                 }
             }
+
             next();
         };
     }

--- a/test/server/server-Spec.js
+++ b/test/server/server-Spec.js
@@ -275,6 +275,10 @@ describe("", function () {
             func({url: "/", method: "PATCH"}, {}, next);
             sinon.assert.notCalled(clientsSpy);
         });
+        it("should NOT call sockets.clients() if the request is sent via AJAX", function () {
+            func({url: "/", method: "PATCH", headers: {"x-requested-with": "XMLHttpRequest"}}, {}, next);
+            sinon.assert.notCalled(clientsSpy);
+        });
 
         it("E2E", function (done) {
             var options = {


### PR DESCRIPTION
This commit adds header checks before triggering the `location:update` event in
`serverUtils.navigateCallback()`. If the request was made via AJAX, the
`x-requested-with` header will contain `XMLHttpRequest` and we can safely avoid
triggering the navigation event.

This prevents any browser from being redirected to a URL made via AJAX.

A test case is included alongside other ghost mode tests.
