### PR TITLE
Changed where gzip was being disabled to fix issues with MAMP

### DIFF
--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -67,6 +67,9 @@ module.exports.createProxy = function (host, ports, options, reqCallback) {
     //
     var server = httpProxy.createServer(function (req, res, proxy) {
 
+        // Alter accept-encoding header to ensure plain-text response
+        req.headers["accept-encoding"] = "*;q=1,gzip=0";
+
         var next = function () {
             proxy.proxyRequest(req, res, {
                 host: proxyOptions.host,
@@ -78,9 +81,6 @@ module.exports.createProxy = function (host, ports, options, reqCallback) {
         if (snippetUtils.isExcluded(req)) {
             return next();
         }
-
-        // Alter accept-encoding header to ensure plain-text response
-        req.headers["accept-encoding"] = "*;q=1,gzip=0";
 
         var tags = messages.scriptTags(host, ports);
 


### PR DESCRIPTION
I had an issue with using the proxy option in front of MAMP. All of my CSS/JS was being injected in the browser as gzipped garbage. I moved the location of the gzip disabling line to just above the next() function. Is there a reason it was in the place it was in? This fixed the issue entirely for me.
