### PR TITLE
Fixes AMD loading

### DIFF
--- a/lib/snippet.js
+++ b/lib/snippet.js
@@ -25,6 +25,9 @@ var utils = {
         ".gif",
         "json"
     ],
+
+    bodyPattern: /<body[^>]*>/i,
+
     /**
      * Check if HTML body exists
      * @param {String} body
@@ -34,7 +37,7 @@ var utils = {
         if (!body) {
             return false;
         }
-        return (~body.lastIndexOf("</body>"));
+        return (body.match(this.bodyPattern));
     },
     /**
      *
@@ -74,8 +77,8 @@ module.exports.write = function (res, tags, rewriteHeaders, callback) {
         var body = string instanceof Buffer ? string.toString() : string;
 
         if (utils.bodyExists(body)) {
-            body = body.replace(/<\/body>/, function (w) {
-                return tags + w;
+            body = body.replace(utils.bodyPattern, function (w) {
+                return w + tags;
             });
         }
 


### PR DESCRIPTION
If you're proxying an app that uses RequireJS and you include the `<script>` tags at the bottom of the `<body>`, the inner app will assume that the modules are being included for it.

This PR instead attaches the `<script>` tags as the first children of the `<body>`, so that browser-sync can start up and its modules won't be in conflict with the inner app's.

Fixes #2 with all tests passing.
