### PR TITLE
Changed accept-encoding header to identity

### DIFF
--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -68,7 +68,7 @@ module.exports.createProxy = function (host, ports, options, reqCallback) {
     var server = httpProxy.createServer(function (req, res, proxy) {
 
         // Alter accept-encoding header to ensure plain-text response
-        req.headers["accept-encoding"] = "*;q=1,gzip=0";
+        req.headers["accept-encoding"] = "identity";
 
         var next = function () {
             proxy.proxyRequest(req, res, {


### PR DESCRIPTION
The compress module on the node connect server doesn't seem to honor q=0 on gzip, so to make the proxy work with an application I have that uses connect, I had to change the accept-encoding to "identity". See https://github.com/senchalabs/connect/issues/414
