### PR TITLE
Sync forms, links, scroll and clicks only when on the relative path

### DIFF
--- a/lib/client/browser-sync-client.js
+++ b/lib/client/browser-sync-client.js
@@ -773,6 +773,7 @@
         if (data.url !== window.location.pathname) {
             return;
         }
+
         scope.ghostMode.enabled = false;
         document.forms[data.id].reset();
     });


### PR DESCRIPTION
Fix for #78.

Any socket event that is URL agnostic, as `"connection"` and `"reload"` isn't protected (as we should expect). `"scroll:update"`, for example, is.

Should we test this or not?
