### PR TITLE
test if notifyElem exists if not creates it

### DIFF
--- a/lib/client/browser-sync-client.js
+++ b/lib/client/browser-sync-client.js
@@ -89,7 +89,7 @@
          * @param {Number} [timeout]
          */
         notify: function (message, elem, timeout) {
-            if(!document.getElementById('notifyElem')) {
+            if(!document.getElementById("notifyElem")) {
                 notifyElem = this.createNotifyElem(styles || null);
             }
             elem.innerHTML = message;


### PR DESCRIPTION
my app cleans out everything inside the body including the elem bsync uses to notify CSS Injections. This should be useful for others using bsync for single page apps
