### PR TITLE
Properly merge array config values

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -53,7 +53,7 @@ if (require.main === module) {
  */
 module.exports.init = function (userFiles, userConfig, cb) {
     var config = _.merge(defaultConfig, userConfig, function (a, b) {
-        return _.isArray(a) ? a.concat(b) : undefined;
+        return _.isArray(a) ? _.union(a, b) : undefined;
     });
     var files  = options._mergeFilesOption(userFiles, config.exclude);
     config = init.mergeOptions(defaultConfig, config, init.allowedOptions);


### PR DESCRIPTION
`_.merge` works if an array contains objects (that is, it merges the properties of the objects). However, if the array contains simple values (such as strings in the case of browser-sync config values), it overwrites the values in the default array with values in the user config.

For example, suppose I call browser-sync with a config object like this (in my case it's in a gulpfile):

```
browserSync.init(["output/**.*"], {
  excludedFileTypes: ["ejs"]
});
```

The default config contains these values:

```
excludedFileTypes: [
  "js",
  "css",
  "pdf",
  "map",
  "svg",
  "ico",
  "woff",
  "json",
  "eot",
  "ttf",
  "png",
  "jpg",
  "jpeg",
  "webp",
  "gif",
  "mp4",
  "mp3",
  "3gp",
  "ogg",
  "ogv",
  "webm",
  "m4a",
  "flv",
  "wmv",
  "avi",
  "swf",
  "scss"
]
```

The result of [the _merge call](https://github.com/shakyShane/browser-sync/blob/master/lib/index.js#L55) in `index.js` is:

```
excludedFileTypes: [
  "ejs",
  "css",
  "pdf",
  "map",
  "svg",
  "ico",
  "woff",
  "json",
  "eot",
  "ttf",
  "png",
  "jpg",
  "jpeg",
  "webp",
  "gif",
  "mp4",
  "mp3",
  "3gp",
  "ogg",
  "ogv",
  "webm",
  "m4a",
  "flv",
  "wmv",
  "avi",
  "swf",
  "scss"
]
```

Note that the user-provided value "ejs" **replaces** the first value ("js") rather than being added to the array.

This pull request changes the behavior of `_.merge` so that for arrays, the arrays are concatenated. Note that a more robust solution would be needed if there were config parameters that accepted arrays of objects, but as long as the only array config parameters use simple values (string, number, etc.) this approach works.
