### PR TITLE
keepHostHeader proxy option

### DIFF
--- a/lib/cli-options.js
+++ b/lib/cli-options.js
@@ -1,6 +1,7 @@
 "use strict";
 
 var path = require("path");
+var _    = require("lodash");
 
 module.exports = {
     /**
@@ -45,51 +46,47 @@ module.exports = {
      */
     _mergeProxyOption: function (defaultValue, arg) {
 
-        var protocol = "http";
-        var host = "localhost";
-        var port = 80;
         var segs;
-        var startPath = false;
-        var returnObj;
-
-        if (typeof arg !== "string") {
-            return false;
-        }
-
-        var url = arg.replace(/^(https?):\/\//, function (match, solo) {
-            protocol = solo;
-            return "";
-        });
-
-        if (~url.indexOf(":")) {
-            segs = url.split(":");
-            host = segs[0];
-            port = parseInt(segs[1], 10);
-        } else {
-            host = url;
-        }
-
-        if (~host.indexOf("/")) {
-            segs = host.split("/");
-            host = segs.shift();
-            startPath = segs.join("/");
-        }
-
-        returnObj = {
-            protocol: protocol,
-            host: host,
-            port: port
+        var url;
+        var options = {
+            protocol: "http",
+            host: "localhost",
+            port: 80
         };
 
-        if (startPath) {
-            returnObj.startPath = startPath;
+        if (arg instanceof Object) {
+            options = _.merge(options, arg || {});
+        } else if (typeof arg === "string") {
+            url = arg.replace(/^(https?):\/\//, function (match, solo) {
+                options.protocol = solo;
+                return "";
+            });
+
+            if (~url.indexOf(":")) {
+                segs = url.split(":");
+                options.host = segs[0];
+                options.port = parseInt(segs[1], 10);
+            } else {
+                options.host = url;
+            }
+
+            if (~options.host.indexOf("/")) {
+                segs = options.host.split("/");
+                options.host = segs.shift();
+                if (segs.length) {
+                    options.startPath = segs.join("/");
+                }
+            }
+        } else {
+            options = false;
         }
 
-        return returnObj;
+        return options;
     },
     /**
      * @param {Object} defaultValue
      * @param {String} arg
+     * @param {Object} [argv] - process.argv
      * @returns {String}
      * @private
      */

--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -97,18 +97,21 @@ module.exports.createProxy = function (host, ports, options, reqCallback) {
     var scriptTags = messages.scriptTags(host, ports, options);
     var proxy = httpProxy.createProxyServer({});
     var snippetMw = snippetUtils.getSnippetMiddleware(scriptTags, rewriteLinks);
+    var proxyWebOptions = { target: utils.getProxyUrl(proxyOptions) };
+
+    if (!proxyOptions.keepHostHeader)
+    {
+        proxyWebOptions.headers = {
+            host: proxyOptions.host
+        };
+    }
 
     var server = require("http").createServer(function(req, res) {
 
         req.headers["accept-encoding"] = "identity";
 
         var next = function () {
-            proxy.web(req, res, {
-                target: utils.getProxyUrl(proxyOptions),
-                headers: {
-                    host: proxyOptions.host
-                }
-            });
+            proxy.web(req, res, proxyWebOptions);
         };
 
         req = snippetUtils.isOldIe(req);


### PR DESCRIPTION
At the essence same as #120, but hidden behind a (disabled by default) option. Fixes #113.

I had to allow setting non-string `proxy` option to make way for `proxy.keepHostHeader`.

[wiki page with options](https://github.com/shakyShane/browser-sync/wiki/options#proxy) will have to be updated.