### PR TITLE
Add option to prevent reload event from triggering unnecessarily. Solves #134

### DIFF
--- a/lib/file-watcher.js
+++ b/lib/file-watcher.js
@@ -2,6 +2,7 @@
 
 var fs = require("fs");
 var Gaze = require("gaze").Gaze;
+var _ = require('lodash');
 
 /**
  * Plugin interface
@@ -60,7 +61,7 @@ module.exports.getWatcher = function (files) {
  */
 module.exports.getChangeCallback = function (options, emitter) {
 
-    return function (filepath) {
+    var callback = function (filepath) {
 
         var chunks = [];
 
@@ -80,4 +81,10 @@ module.exports.getChangeCallback = function (options, emitter) {
             }
         }
     };
+
+    if (options.debounce > 0) {
+        return _.debounce(callback, options.debounce);
+    } else {
+        return callback;
+    }
 };


### PR DESCRIPTION
I added a `debounce` option that when used turns the change callback function into a debounced function a la Lodash that will wait `options.debounce` milliseconds since the last call to actually execute. If the `debounce` option isn't provided or is 0, then it behave as it did before this change.
