### PR TITLE
Adding port on the header so it works on zope/plone

### DIFF
--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -98,11 +98,11 @@ module.exports.createProxy = function (host, ports, options, reqCallback) {
     var proxy = httpProxy.createProxyServer({});
     var snippetMw = snippetUtils.getSnippetMiddleware(scriptTags, rewriteLinks);
 
-    var host_header = ""
+    var hostHeader = "";
     if (proxyOptions.port && proxyOptions.port !== 80) {
         hostHeader = proxyOptions.host + ":" + proxyOptions.port;
     } else {
-        hostHeader = proxyOptions.host
+        hostHeader = proxyOptions.host;
     }
 
     var server = require("http").createServer(function(req, res) {


### PR DESCRIPTION
Some days ago @sneridagh asked why it doesn't work on plone/zope and it's because the hostname on the header needs to have it's port on it or we are rewriting the urls to the same request url getting wrong links.

With this patch we send also the port to the header.
