### PR TITLE
Fix to include port in headers on proxy calls if different from port 80

### DIFF
--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -106,7 +106,7 @@ module.exports.createProxy = function (host, ports, options, reqCallback) {
             proxy.web(req, res, {
                 target: utils.getProxyUrl(proxyOptions),
                 headers: {
-                    host: proxyOptions.host
+                    host: utils.getProxyHost(proxyOptions)
                 }
             });
         };


### PR DESCRIPTION
As requested, fixed following your suggestion.
Thanks!
