### PR TITLE
Add option for server logging

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -154,16 +154,16 @@ module.exports.launchServer = function (host, ports, options, io) {
             utils.addMiddleware(app, server.middleware);
         }
 
+        if (server.logger) {
+            app.use(connect.logger(server.logger));
+        }
+
         app.use(function (req, res, next) {
                 req = snippetUtils.isOldIe(req);
                 return next();
             })
             .use(navCallback)
             .use(snippetUtils.getSnippetMiddleware(scriptTags));
-
-        if(options.logger) {
-            app.use(connect.logger(options.logger));
-        }
 
         utils.addBaseDir(app, baseDir, index);
 


### PR DESCRIPTION
This commit adds an option to enable server logging through connect's built in [logger](http://www.senchalabs.org/connect/logger.html). 

Usage:

``` js
browserSync.init(['build/**'], {
  server: {
    baseDir: 'build'
  },
  logger: 'dev' // or any other value accepted by connect.logger()
});
```

![image](https://cloud.githubusercontent.com/assets/647549/3180985/eb63621c-ec38-11e3-90b7-be4abcaae8d9.png)
:point_up: Pretty!

I couldn't quite figure out how to your tests running, so one still needs to be written if you think the change needs one.
