### PR TITLE
High CPU when watching files

### DIFF
--- a/lib/file-watcher.js
+++ b/lib/file-watcher.js
@@ -26,7 +26,7 @@ module.exports.init = function (files, options, emitter) {
     var watchCallback = exports.getWatchCallback(emitter);
     var changeCallback = exports.getChangeCallback(options, emitter);
 
-    var watchOptions = options.watch || {};
+    var watchOptions = options.watchOptions || options.watchoptions || {};
 
     var watcher = exports.getWatcher(files, watchOptions);
 


### PR DESCRIPTION
We are using grunt inside a VirtualBox VM which causes high CPU usage while watching for file changes. The VM can't use efficient file system eventing to detect changes when sharing files with the host. To combat hot-laptop-syndrome, we've had success with forcing grunt-contrib-watch to poll less frequently, but can't do this with the current version of browser-sync (which I'd like to use instead of livereload because it's great).

This is a known issue with node, grunt-watch, etc:
https://github.com/gruntjs/grunt-contrib-watch#why-is-the-watch-devouring-all-my-memorycpu

My pull request allows a config object to be passed to the Gaze object, which seems to work for my situation.

More info on Gaze options:
https://github.com/shama/gaze#properties
