### PR TITLE
Fix hardcoded port (3000) for JS injection

### DIFF
--- a/lib/messages.js
+++ b/lib/messages.js
@@ -119,11 +119,11 @@ var messages = {
 
         var template = [
             "\n<script type='text/javascript'>//<![CDATA[\n",
-            "document.write(\"<script async src='{:custom:}'><\\/script>\".replace(/HOST/g, location.hostname));",
+            "document.write(\"<script async src='{:custom:}'><\\/script>\".replace(/HOST/g, location.hostname).replace(/PORT/g, location.port));",
             "\n//]]></script>"
         ];
 
-        var script = "//HOST:" + port + this.clientScript(options);
+        var script = "//HOST:PORT" + this.clientScript(options);
 
         if (options.tunnel) {
             script = this.clientScript(options);

--- a/test/specs/cli/cli.messages.js
+++ b/test/specs/cli/cli.messages.js
@@ -19,7 +19,7 @@ describe("CLI: Messages", function () {
             var expected = "[BS] Copy the following snippet into your website, just before the closing </body> tag";
             expected    += "\n\n<script type='text/javascript'>//<![CDATA[\n";
             expected    += "document.write(\"";
-            expected    += "<script async src='//HOST:3000/browser-sync-client.1.2.3.js'><\\/script>\".replace(/HOST/g, location.hostname));";
+            expected    += "<script async src='//HOST:PORT/browser-sync-client.1.2.3.js'><\\/script>\".replace(/HOST/g, location.hostname).replace(/PORT/g, location.port));";
             expected    += "\n//]]></script>\n";
 
             var actual   = ansiTrim(messages.initSnippet(3000, {version: "1.2.3"}));
@@ -206,7 +206,7 @@ describe("CLI: Messages", function () {
         it("can output the new snippet", function () {
             var expected = "\n<script type='text/javascript'>//<![CDATA[\n";
             expected    += "document.write(\"";
-            expected    += "<script async src='//HOST:3000/browser-sync-client.2.3.4.js'><\\/script>\".replace(/HOST/g, location.hostname));";
+            expected    += "<script async src='//HOST:PORT/browser-sync-client.2.3.4.js'><\\/script>\".replace(/HOST/g, location.hostname).replace(/PORT/g, location.port));";
             expected    += "\n//]]></script>\n";
 
             var actual = messages.scriptTags(3000, {version:"2.3.4"});
@@ -215,7 +215,7 @@ describe("CLI: Messages", function () {
         it("can output the new snippet for the tunnel", function () {
             var expected = "\n<script type='text/javascript'>//<![CDATA[\n";
             expected    += "document.write(\"";
-            expected    += "<script async src='/browser-sync-client.2.3.4.js'><\\/script>\".replace(/HOST/g, location.hostname));";
+            expected    += "<script async src='/browser-sync-client.2.3.4.js'><\\/script>\".replace(/HOST/g, location.hostname).replace(/PORT/g, location.port));";
             expected    += "\n//]]></script>\n";
 
             var actual = messages.scriptTags(3000, {version:"2.3.4", tunnel: true});
@@ -224,7 +224,7 @@ describe("CLI: Messages", function () {
         it("can retrieve the injector", function () {
             var expected = "\n<script type='text/javascript'>//<![CDATA[\n";
             expected    += "document.write(\"";
-            expected    += "<script async src='//HOST:3000/browser-sync-client.2.3.5.js'><\\/script>\".replace(/HOST/g, location.hostname));";
+            expected    += "<script async src='//HOST:PORT/browser-sync-client.2.3.5.js'><\\/script>\".replace(/HOST/g, location.hostname).replace(/PORT/g, location.port));";
             expected    += "\n//]]></script>\n";
 
             var actual = messages.scriptTags(3000, {version:"2.3.5"});


### PR DESCRIPTION
This will fix the combination of port tunneling (with ngrok) and browser-sync’s live update mechanism.
https://github.com/shakyShane/browser-sync/issues/176
