### PR TITLE
Add option logSnippet

### DIFF
--- a/lib/default-config.js
+++ b/lib/default-config.js
@@ -110,6 +110,13 @@ module.exports = {
     logFileChanges: true,
 
     /**
+     * Log the snippet to the console when you're in snippet mode (no proxy/server)
+     * @type: Boolean
+     * @default true
+     */
+    logSnippet: true,
+
+    /**
      * @property tunnel
      * @type String|Boolean
      * @default null

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -142,7 +142,7 @@ module.exports.callbacks = {
             logUrls(options.urls);
         }
 
-        if (type === "snippet") {
+        if (type === "snippet" && options.logSnippet) {
 
             logger.info("Copy the following snippet into your website, just before the closing {cyan:</body>} tag");
             logger.unprefixed("info",

--- a/test/specs/e2e/e2e.options.logSnippet.js
+++ b/test/specs/e2e/e2e.options.logSnippet.js
@@ -1,0 +1,32 @@
+"use strict";
+
+var browserSync = require("../../../index");
+
+var assert      = require("chai").assert;
+var sinon       = require("sinon");
+
+
+describe("E2E `logSnippet` option", function () {
+
+    var instance;
+    var spy;
+
+    before(function (done) {
+        var config = {
+            online: false,
+            open: false,
+            logSnippet: false
+        };
+        instance = browserSync(config, done);
+        spy      = sinon.spy(console, "log");
+    });
+
+    after(function () {
+        instance.cleanup();
+        spy.restore();
+    });
+
+    it("Can set the log snippet when given in options", function () {
+        sinon.assert.notCalled(spy);
+    });
+});


### PR DESCRIPTION
I'm having trouble making the test work, if you have any idea ?

 1) E2E `logSnippet` option Can set the log snippet when given in options:
     TypeError: Cannot read property 'args' of null
      at Context.<anonymous> (C:\wamp\www\browser-sync\test\specs\e2e\e2e.options.logSnippet.js:31:33)
      at callFn (C:\wamp\www\browser-sync\node_modules\mocha\lib\runnable.js:249:21)
      at Test.Runnable.run (C:\wamp\www\browser-sync\node_modules\mocha\lib\runnable.js:242:7)
      at Runner.runTest (C:\wamp\www\browser-sync\node_modules\mocha\lib\runner.js:373:10)
      at C:\wamp\www\browser-sync\node_modules\mocha\lib\runner.js:451:12
      at next (C:\wamp\www\browser-sync\node_modules\mocha\lib\runner.js:298:14)
      at C:\wamp\www\browser-sync\node_modules\mocha\lib\runner.js:308:7
      at next (C:\wamp\www\browser-sync\node_modules\mocha\lib\runner.js:246:23)
      at Object._onImmediate (C:\wamp\www\browser-sync\node_modules\mocha\lib\runner.js:275:5)
      at processImmediate [as _immediateCallback](timers.js:336:15)

npm ERR! browser-sync@1.5.1 unit: `mocha --recursive test/specs --reporter spec --timeout 10000`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the browser-sync@1.5.1 unit script.
npm ERR! This is most likely a problem with the browser-sync package,
npm ERR! not with npm itself.
npm ERR! Tell the author that this fails on your system:
npm ERR!     mocha --recursive test/specs --reporter spec --timeout 10000
npm ERR! You can get their info via:
npm ERR!     npm owner ls browser-sync
npm ERR! There is likely additional logging output above.
npm ERR! System Windows_NT 6.2.9200
npm ERR! command "C:\Program Files\nodejs\\node.exe" "C:\Program Files\nodejs\node_modules\npm\bin\npm-cli.js"
 "run" "unit"
npm ERR! cwd C:\wamp\www\browser-sync
npm ERR! node -v v0.10.28
npm ERR! npm -v 1.4.9
npm ERR! code ELIFECYCLE
npm ERR!
npm ERR! Additional logging details can be found in:
npm ERR!     C:\wamp\www\browser-sync\npm-debug.log
npm ERR! not ok code 0

Other than that, the option works fine !
