### PR TITLE
reporting errors on tunnel creation

### DIFF
--- a/lib/tunnel.js
+++ b/lib/tunnel.js
@@ -20,6 +20,10 @@ module.exports.plugin = function (bs, port, cb) {
 //    debug("Trying tunnel connection with: %s ", options.tunnel || "no subdomain specified");
 
     localTunnel(port, opts, function (err, tunnel) {
+        if (err) {
+            console.log(err);
+            throw err;
+        }
         options.urls.tunnel = tunnel.url;
         cb(tunnel.url, true);
     });


### PR DESCRIPTION
this tricked me for a while after I did this change and saw the real error: `[Error: Invalid subdomain. Subdomains must be between 4 and 20 alphanumeric characters.]`
