### PR TITLE
fix typo in middleware examples

### DIFF
--- a/examples/proxy.middleware.js
+++ b/examples/proxy.middleware.js
@@ -18,7 +18,7 @@ browserSync({
     files: ["app/css/*.css"],
     proxy: {
         target: "http://yourlocal.dev",
-        middeware: function (req, res, next) {
+        middleware: function (req, res, next) {
             console.log(req.url);
             next();
         }

--- a/examples/proxy.middleware.multi.js
+++ b/examples/proxy.middleware.multi.js
@@ -28,7 +28,7 @@ browserSync({
     files: ["app/css/*.css"],
     proxy: {
         target: "http://yourlocal.dev",
-        middeware: [fn1, fn2]
+        middleware: [fn1, fn2]
     },
     https: true
 });


### PR DESCRIPTION
I just noticed this typo in the new examples. Thanks again for implementing this so quick. :-)