### PR TITLE
Add HTTPS snippet support

### DIFF
--- a/lib/server/snippet-server.js
+++ b/lib/server/snippet-server.js
@@ -2,6 +2,8 @@
 
 var connect = require("connect");
 var http    = require("http");
+var https   = require("https");
+var utils   = require("./utils.js");
 
 /**
  * Create a server for the snippet
@@ -11,13 +13,22 @@ var http    = require("http");
  */
 module.exports = function createSnippetServer (bs, scripts) {
 
+    var options = bs.options;
+
     var app = connect();
 
-    app.use(bs.options.getIn(["scriptPaths", "versioned"]), scripts)
-       .use(bs.options.getIn(["scriptPaths", "path"]),      scripts);
+    app.use(options.getIn(["scriptPaths", "versioned"]), scripts)
+        .use(options.getIn(["scriptPaths", "path"]),      scripts);
 
+    /**
+     * Finally, return the server + App
+     */
     return {
-        server: http.createServer(app),
-        app:    app
+        server: (function () {
+            return options.get("scheme") === "https"
+                ? https.createServer(utils.getKeyAndCert(options), app)
+                : http.createServer(app);
+        })(app),
+        app: app
     };
 };

--- a/lib/server/snippet-server.js
+++ b/lib/server/snippet-server.js
@@ -18,7 +18,7 @@ module.exports = function createSnippetServer (bs, scripts) {
     var app = connect();
 
     app.use(options.getIn(["scriptPaths", "versioned"]), scripts)
-        .use(options.getIn(["scriptPaths", "path"]),      scripts);
+       .use(options.getIn(["scriptPaths", "path"]),      scripts);
 
     /**
      * Finally, return the server + App

--- a/test/specs/e2e/e2e.snippet.js
+++ b/test/specs/e2e/e2e.snippet.js
@@ -5,7 +5,7 @@ var browserSync   = require("../../../index");
 var request = require("supertest");
 var assert  = require("chai").assert;
 
-describe("E2E Snippet tests", function () {
+describe("E2E snippet tests", function () {
 
     var instance;
 
@@ -25,6 +25,37 @@ describe("E2E Snippet tests", function () {
     });
 
     it("returns the snippet URL", function (done) {
+
+        request(instance.server)
+            .get(instance.options.getIn(["scriptPaths", "versioned"]))
+            .expect(200)
+            .end(function (err, res) {
+                assert.include(res.text, "Connected to BrowserSync");
+                done();
+            });
+    });
+});
+describe("E2E TLS snippet tests", function () {
+
+    var instance;
+
+    before(function (done) {
+
+        browserSync.reset();
+
+        var config = {
+            https:    true,
+            logLevel: "silent"
+        };
+
+        instance = browserSync.init(config, done).instance;
+    });
+
+    after(function () {
+        instance.cleanup();
+    });
+
+    it("returns the snippet URL over HTTPS", function (done) {
 
         request(instance.server)
             .get(instance.options.getIn(["scriptPaths", "versioned"]))


### PR DESCRIPTION
This should fix #459 by checking the https config value and serving the snippet from the proper server.