### PR TITLE
Don't trim whitespace from Markdown-files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -5,6 +5,7 @@ root = true
 
 [*]
 charset = "utf8"
+insert_final_newline = true
 
 
 [*.css]
@@ -23,3 +24,7 @@ trim_trailing_whitespace = true
 indent_style = space
 indent_size = 2
 trim_trailing_whitespace = true
+
+
+[*.md]
+trim_trailing_whitespace = false


### PR DESCRIPTION
I don't know if the last change messed anything up, but this should at least try to make sure it doesn't happen in the future