### PR TITLE
Foxy cookies.stripDomain option configurable

### DIFF
--- a/lib/server/proxy-server.js
+++ b/lib/server/proxy-server.js
@@ -51,6 +51,10 @@ function getOptions (bs, scripts) {
         out.reqHeaders = options.getIn(["proxy", "reqHeaders"]);
     }
 
+    if (options.getIn(["proxy", "cookies"])) {
+        out.cookies = options.getIn(["proxy", "cookies"]);
+    }
+
     return out;
 }
 


### PR DESCRIPTION
The cookies.stripDomain option is enabled by default in Foxy.
The problem with that is that there is no way of preventing the proxy server from altering your cookies. In some cases altering the cookies may break the session, like in this case: shakyShane/foxy#6

It's anyway good citizenship to have the option to opt-out from features that may corrupt the request headers in edge cases like that.

I hope you don't mind no test case, as I couldn't find one for the opt.proxy.reqHeaders feature either ;)