### PR TITLE
Serve-static option: 'extensions'

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -50,11 +50,11 @@ gulp.task("sass", function () {
  */
 gulp.task("browser-sync", function () {
 
-//    var clientScript = require("/Users/shakyshane/Sites/browser-sync-modules/browser-sync-client/index");
-//
-//    browserSync.use("client:script", clientScript.middleware, function (err) {
-//        console.log(err);
-//    });
+    // var clientScript = require("/Users/shakyshane/Sites/browser-sync-modules/browser-sync-client/index");
+    //
+    // browserSync.use("client:script", clientScript.middleware, function (err) {
+    //     console.log(err);
+    // });
 
     browserSync({
         server: "test/fixtures",

--- a/lib/cli/cli-options.js
+++ b/lib/cli/cli-options.js
@@ -93,6 +93,10 @@ opts.callbacks = {
             if (argv.directory) {
                 obj.directory = true;
             }
+
+            if (argv.extensions) {
+                obj.extensions = argv.extensions;
+            }
         }
 
         return Immutable.fromJS(obj);

--- a/lib/cli/opts.json
+++ b/lib/cli/opts.json
@@ -8,6 +8,7 @@
     "startPath":     "Specify the start path for the opened browser",
     "https":         "Enable SSL for local development",
     "directory":     "Show a directory listing for the server",
+    "extensions":    "Specify file extension fallbacks",
     "proxy":         "Proxy an existing server",
     "xip":           "Use xip.io domain routing",
     "tunnel":        "Use a public URL",

--- a/lib/options.js
+++ b/lib/options.js
@@ -110,6 +110,9 @@ function setServerOpts(item) {
         if (item.get("index")) {
             item.setIn(["server", "index"], item.get("index"));
         }
+        if (item.get("extensions")) {
+            item.setIn(["server", "extensions"], item.get("extensions"));
+        }
     }
 }
 

--- a/lib/server/static-server.js
+++ b/lib/server/static-server.js
@@ -16,7 +16,7 @@ module.exports = function createServer (bs, scripts) {
     var middleware = options.get("middleware");
     var index      = server.get("index") || "index.html";
     var basedir    = server.get("baseDir");
-    var extensions = server.get("extensions") || ['html', 'htm'];
+    var extensions = server.get("extensions") || ["html", "htm"];
 
     var app = connect();
 

--- a/lib/server/static-server.js
+++ b/lib/server/static-server.js
@@ -16,6 +16,7 @@ module.exports = function createServer (bs, scripts) {
     var middleware = options.get("middleware");
     var index      = server.get("index") || "index.html";
     var basedir    = server.get("baseDir");
+    var extensions = server.get("extensions") || ['html', 'htm'];
 
     var app = connect();
 
@@ -56,7 +57,7 @@ module.exports = function createServer (bs, scripts) {
     /**
      * Add Serve static middlewares
      */
-    utils.addBaseDir(app, basedir, index);
+    utils.addBaseDir(app, basedir, index, extensions);
 
     /**
      * Add further Serve static middlewares for routes

--- a/lib/server/utils.js
+++ b/lib/server/utils.js
@@ -30,15 +30,15 @@ var utils = {
      * @param base
      * @param index
      */
-    addBaseDir: function (app, base, index) {
+    addBaseDir: function (app, base, index, extensions) {
 
         if (isList(base)) {
             base.forEach(function (item) {
-                app.use(serveStatic(filePath.resolve(item), {index: index}));
+                app.use(serveStatic(filePath.resolve(item), {index: index, extensions: extensions}));
             });
         } else {
             if (_.isString(base)) {
-                app.use(serveStatic(filePath.resolve(base), {index: index}));
+                app.use(serveStatic(filePath.resolve(base), {index: index, extensions: extensions}));
             }
         }
     },

--- a/test/specs/cli/cli.options.server.js
+++ b/test/specs/cli/cli.options.server.js
@@ -54,7 +54,7 @@ describe("CLI: Options: Merging Server Options", function () {
         assert.equal(imm.getIn(["server", "index"]), "index.htm");
         assert.isFunction(imm.getIn(["server", "middleware"]));
     });
-    it("can merge cli flags into object", function () {
+    it("can merge cli server, index flags into object", function () {
         var argv = {
             server: true,
             index: "index.htm"
@@ -65,7 +65,7 @@ describe("CLI: Options: Merging Server Options", function () {
             index: "index.htm"
         });
     });
-    it("can merge cli flags into object", function () {
+    it("can merge cli server, directory flags into object", function () {
         var argv = {
             server: true,
             directory: true
@@ -76,18 +76,20 @@ describe("CLI: Options: Merging Server Options", function () {
             directory: true
         });
     });
-    it("can merge cli flags into object", function () {
+    it("can merge cli server, index, extensions flags into object", function () {
         var argv = {
-            server: true,
-            directory: true
+            server: "app",
+            index: "file.html",
+            extensions: ["html", "json"]
         };
-        var imm = merge({}, argv);
+        var imm = merge({server: "app"}, argv);
         assert.deepEqual(imm.get("server").toJS(), {
-            baseDir: "./",
-            directory: true
+            baseDir: "app",
+            index: "file.html",
+            extensions: ["html", "json"]
         });
     });
-    it("can merge cli flags into object", function () {
+    it("can merge cli server, directory, index flags into object", function () {
         var argv = {
             server: "app",
             directory: true,

--- a/test/specs/e2e/cli/e2e.cli.server.js
+++ b/test/specs/e2e/cli/e2e.cli.server.js
@@ -74,7 +74,8 @@ describe("E2E CLI server test with directory listing/index ", function () {
                     online: false,
                     logLevel: "silent",
                     directory: true,
-                    index: "index.htm"
+                    index: "index.htm",
+                    extensions: "html"
                 }
             },
             cb: function (err, bs) {
@@ -89,5 +90,6 @@ describe("E2E CLI server test with directory listing/index ", function () {
     it("Sets the correct server options", function () {
         assert.equal(instance.options.getIn(["server", "directory"]), true);
         assert.equal(instance.options.getIn(["server", "index"]), "index.htm");
+        assert.equal(instance.options.getIn(["server", "extensions"]), "html");
     });
 });


### PR DESCRIPTION
Allows the use of `serve-static`'s [`extensions` option](https://github.com/expressjs/serve-static#extensions).

> ##### extensions
> Set file extension fallbacks. When set, if a file is not found, the given extensions will be added to the file name and search for. The first that exists will be served. Example: ['html', 'htm'].

This adds the option to `utils.addBaseDir`, adds a cli option, and adds the option to `e2e.cli.server.js`.

### usage

```js
browserSync({
    server: {
      baseDir: 'src',
      extensions: ['html', 'json']
    }
  });
```

### cli usage
```bash
$ browser-sync start --server build --extensions 'json'
```