### PR TITLE
Modernized package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <p align="center">
-<a href="https://ci.appveyor.com/project/shakyShane/browser-sync" title="AppVeyor branch">
- <img src="https://img.shields.io/appveyor/ci/shakyshane/browser-sync/master.svg?style=flat-square&label=windows" />
+<a href="https://ci.appveyor.com/project/cchamberlain/browser-sync" title="AppVeyor branch">
+ <img src="https://ci.appveyor.com/api/projects/status/xjhva67tkqkvdxxn/branch/master?svg=true&style=flat-square&label=windows" />
 </a>
 <a href="https://travis-ci.org/BrowserSync/browser-sync" title="Travis branch">
  <img src="https://img.shields.io/travis/BrowserSync/browser-sync/master.svg?style=flat-square&label=linux" />

--- a/README.md
+++ b/README.md
@@ -31,6 +31,13 @@
 <p align="center">Follow <a href="https://twitter.com/browsersync">@BrowserSync</a> on twitter for news & updates.</p>
 <p align="center">Talk to contributors on <a href="https://gitter.im/BrowserSync/browser-sync"><img src="https://badges.gitter.im/Join%20Chat.svg" /></a></p>
 
+***The original project is currently breaking on Windows due to references in the various socket.io/engine.io projects back to old versions of ws.  I forked the socket.io/engine.io projects, updated the references to use latest ws and pointed this forked browser-sync at the updated socket.io and it works for me again on Windows.  This has been an open issue for a while and doesn't seem to be getting much attention.***
+
+***See:***
+(https://github.com/Automattic/socket.io/issues/2056#issuecomment-104475530)
+(https://github.com/Automattic/socket.io/issues/2114)
+
+
 ## Features
 
 Please visit [browsersync.io](http://browsersync.io) for a full run-down of features

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <p align="center">
-<a href="https://ci.appveyor.com/project/cchamberlain/browser-sync" title="AppVeyor branch">
- <img src="https://ci.appveyor.com/api/projects/status/xjhva67tkqkvdxxn/branch/master?svg=true&style=flat-square&label=windows" />
+<a href="https://ci.appveyor.com/project/shakyShane/browser-sync" title="AppVeyor branch">
+ <img src="https://img.shields.io/appveyor/ci/shakyshane/browser-sync/master.svg?style=flat-square&label=windows" />
 </a>
 <a href="https://travis-ci.org/BrowserSync/browser-sync" title="Travis branch">
  <img src="https://img.shields.io/travis/BrowserSync/browser-sync/master.svg?style=flat-square&label=linux" />
@@ -30,13 +30,6 @@
 <p align="center">BrowserSync is developed and maintained internally at <a href="http://www.wearejh.com">JH</a></p>
 <p align="center">Follow <a href="https://twitter.com/browsersync">@BrowserSync</a> on twitter for news & updates.</p>
 <p align="center">Talk to contributors on <a href="https://gitter.im/BrowserSync/browser-sync"><img src="https://badges.gitter.im/Join%20Chat.svg" /></a></p>
-
-***The original project is currently breaking on Windows due to references in the various socket.io/engine.io projects back to old versions of ws.  I forked the socket.io/engine.io projects, updated the references to use latest ws and pointed this forked browser-sync at the updated socket.io and it works for me again on Windows.  This has been an open issue for a while and doesn't seem to be getting much attention.***
-
-***See:***
-(https://github.com/Automattic/socket.io/issues/2056#issuecomment-104475530)
-(https://github.com/Automattic/socket.io/issues/2114)
-
 
 ## Features
 

--- a/package.json
+++ b/package.json
@@ -40,8 +40,8 @@
     "easy-extender": "^2.3.1",
     "eazy-logger": "^2.1.2",
     "emitter-steward": "^0.0.1",
-    "engine.io": "automattic/engine.io",
-    "engine.io-client": "automattic/engine.io-client",
+    "engine.io": "automattic/engine.io#860af4dc0b47e55a623e7e56ce097ba4b610264b",
+    "engine.io-client": "automattic/engine.io-client#cffcc899546d451e53f7d8e8a309272f95099148",
     "foxy": "^10.1.2",
     "immutable": "^3.6.4",
     "localtunnel": "^1.3.0",
@@ -56,7 +56,7 @@
     "serve-index": "^1.6.3",
     "serve-static": "^1.9.1",
     "socket.io": "^1.3.5",
-    "socket.io-client": "automattic/socket.io-client",
+    "socket.io-client": "automattic/socket.io-client#e898166382f7a811cf0e1b07b53ddb61b43b238a",
     "ua-parser-js": "^0.7.7",
     "ucfirst": "^0.0.1",
     "ws": "^0.7.2"
@@ -82,7 +82,7 @@
     "request": "^2.55.0",
     "sinon": "^1.12.1",
     "slugify": "^0.1.0",
-    "socket.io-client": "^1.3.5",
+    "socket.io-client": "automattic/socket.io-client#e898166382f7a811cf0e1b07b53ddb61b43b238a",
     "supertest": "^0.15.0",
     "vinyl": "^0.4.5"
   },

--- a/package.json
+++ b/package.json
@@ -40,6 +40,8 @@
     "easy-extender": "^2.3.1",
     "eazy-logger": "^2.1.2",
     "emitter-steward": "^0.0.1",
+    "engine.io": "automattic/engine.io",
+    "engine.io-client": "automattic/engine.io-client",
     "foxy": "^10.1.2",
     "immutable": "^3.6.4",
     "localtunnel": "^1.3.0",
@@ -53,9 +55,11 @@
     "resp-modifier": "^2.1.0",
     "serve-index": "^1.6.3",
     "serve-static": "^1.9.1",
-    "socket.io": "cchamberlain/socket.io",
+    "socket.io": "^1.3.5",
+    "socket.io-client": "automattic/socket.io-client",
     "ua-parser-js": "^0.7.7",
-    "ucfirst": "^0.0.1"
+    "ucfirst": "^0.0.1",
+    "ws": "^0.7.2"
   },
   "devDependencies": {
     "browser-sync-spa": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "resp-modifier": "^2.1.0",
     "serve-index": "^1.6.3",
     "serve-static": "^1.9.1",
-    "socket.io": "^1.3.5",
+    "socket.io": "cchamberlain/socket.io",
     "ua-parser-js": "^0.7.7",
     "ucfirst": "^0.0.1"
   },

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "browser-sync-x",
+  "name": "browser-sync",
   "description": "Live CSS Reload & Browser Syncing",
   "version": "2.7.3",
   "homepage": "http://www.browsersync.io/",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "browser-sync",
+  "name": "browser-sync-x",
   "description": "Live CSS Reload & Browser Syncing",
   "version": "2.7.3",
   "homepage": "http://www.browsersync.io/",


### PR DESCRIPTION
The current package references socket.io npm package which is broken on Windows.  The reason it is broken, is that it has references to engine.io-client and engine.io which reference outdated versions of ws.  This updates the package.json to reference the latest npm socket.io package (which is fine) but also saves automattic/socket.io-client, automattic/engine.io, and automattic/engine.io-client, and ws@latest packages as dependencies, which causes socket.io to use the updated references vs the ones on npm which are not unified across packages.  This seems to be the best current workaround until the latest socket.io packages are published to use the latest ws package on npm.