### PR TITLE
Better dotfiles detection

### DIFF
--- a/lib/file-watcher.js
+++ b/lib/file-watcher.js
@@ -12,7 +12,7 @@ module.exports.plugin = function (bs) {
     var emitter = bs.emitter;
 
     var defaultWatchOptions = require("immutable").Map({
-        ignored:  /[\/\\]\./
+        ignored:  /^([.][^.\/\\])|([\/\\]+[.][^.])/
     })
     .mergeDeep(
         options.get("watchOptions") || options.get("watchoptions")


### PR DESCRIPTION
The default regex used to ignore dotfiles isn't as specific as it could be, causing false positives like `../../`
As explained in BrowserSync/grunt-browser-sync/issues/118.
This one fixes it.