### PR TITLE
Add some extra documentation around rewriting rules

### DIFF
--- a/lib/default-config.js
+++ b/lib/default-config.js
@@ -197,10 +197,15 @@ module.exports = {
     },
 
     /**
-     * Add additional HTML rewriting rules.
+     * Add additional HTML rewriting rules.  Replacements may be provided by a callback or a string.  See
+     * [String.prototype.replace()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace#Specifying_a_string_as_a_parameter)
+     * for details.
      * @property rewriteRules
      * @since 2.4.0
      * @type Array|Boolean
+     * @param {RegExp} match
+     * @param {Function} [fn=undefined]
+     * @param {String} [replace]
      * @default false
      */
     rewriteRules: false,


### PR DESCRIPTION
Makes it clear that BrowserSync is just using String.prototype.replace() under the hood, as the default callback syntax is kind of clunky for most cases.

Once [resp-modifier](https://www.npmjs.com/package/resp-modifier) is documented, we can probably point users over there, although I'm not quite sure which bits of that API are "public," and in need of documenting.
