### PR TITLE
Prefer HTTP/2 or SPDY in favor of https.

### DIFF
--- a/lib/cli/opts.start.json
+++ b/lib/cli/opts.start.json
@@ -7,7 +7,7 @@
     "index":            "Specify which file should be used as the index page",
     "extensions":       "Specify file extension fallbacks",
     "startPath":        "Specify the start path for the opened browser",
-    "https":            "Enable SSL for local development",
+    "https":            "Enable SPDY with https fallback for local development",
     "directory":        "Show a directory listing for the server",
     "proxy":            "Proxy an existing server",
     "ws":               "Proxy mode only - enable websocket proxying",

--- a/lib/default-config.js
+++ b/lib/default-config.js
@@ -100,8 +100,9 @@ module.exports = {
     serveStatic: [],
 
     /**
-     * Enable https for localhost development. **Note** - this is not needed for proxy
-     * option as it will be inferred from your target url.
+     * Enable SPDY with https fallback for localhost development. **Note** -
+     * this is not needed for proxy option as it will be inferred from your
+     * target url.
      * @property https
      * @type Boolean
      * @default undefined

--- a/lib/server/utils.js
+++ b/lib/server/utils.js
@@ -6,7 +6,7 @@ var serveIndex   = require("serve-index");
 var serveStatic  = require("serve-static");
 var _            = require("lodash");
 var http         = require("http");
-var https        = require("https");
+var spdy         = require("spdy");
 var Immutable    = require("immutable");
 var isList       = Immutable.List.isList;
 var snippetUtils = require("./../snippet").utils;
@@ -95,7 +95,7 @@ var utils = {
         return next();
     },
     /**
-     * Get either an http or https server
+     * Get either an http or spdy/https server
      */
     getServer: function (app, options) {
         return {
@@ -103,8 +103,8 @@ var utils = {
                 if (options.get("scheme") === "https") {
                     var pfxPath = options.getIn(["https", "pfx"]);
                     return pfxPath ?
-                        https.createServer(utils.getPFX(pfxPath), app) :
-                        https.createServer(utils.getKeyAndCert(options), app);
+                        spdy.createServer(utils.getPFX(pfxPath), app) :
+                        spdy.createServer(utils.getKeyAndCert(options), app);
                 }
                 return http.createServer(app);
             })(),

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "serve-index": "^1.7.0",
     "serve-static": "^1.10.0",
     "socket.io": "^1.3.7",
+    "spdy": "^2.0.5",
     "ua-parser-js": "^0.7.9",
     "ucfirst": "^1.0.0"
   },


### PR DESCRIPTION
Replaces the https module with SPDY which provides HTTP/2 with fallback
to SPDY and regular https for old browsers.

Related issue: #854