### PR TITLE
Remove unnecessary variable

### DIFF
--- a/index.js
+++ b/index.js
@@ -282,7 +282,7 @@ function create(name, emitter) {
     name    = name    || new Date().getTime();
     emitter = emitter || newEmitter();
 
-    var browserSync = new BrowserSync(emitter, name);
+    var browserSync = new BrowserSync(emitter);
 
     var instance = {
         name:      name,


### PR DESCRIPTION
`name` is not used in [constructor](https://github.com/BrowserSync/browser-sync/blob/a18cdc3cd6d7f21f45f38e857e15a73d282c9e21/lib/browser-sync.js#L32-L50).