### PR TITLE
Adding ability to specify the localhost URI via config options

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -46,6 +46,11 @@ var utils = {
         var external  = utils.xip(utils.getHostIp(options, devIp), options);
         var localhost = "localhost";
 
+        if (options.get("localhost")) {
+            localhost = options.get("localhost");
+        }
+
+
         if (options.get("xip")) {
             localhost = "127.0.0.1";
         }


### PR DESCRIPTION
since browsersync launches a browser window once it start ups, it would be nice to be able to specify the host. Yes localhost works. We use different urls (all mapped to 127.0.0.1) different and rely on the domain name for certain features... Therefore, it would be nice if we were able to configure the domain of the freshly opened window (i.e. something other than localhost). All this does is add a 'localhost' option to the config. If specified, this will be used rather than 'localhost'... so 
{ localhost: 'local-foobar.com' }
would cause browsersync to launch a new window at "http://local-foobar.com:3000" after the server loads.