### PR TITLE
Remove unnecessary return

### DIFF
--- a/lib/async.js
+++ b/lib/async.js
@@ -181,7 +181,7 @@ module.exports = {
      */
     mergeMiddlewares: function (bs, done) {
 
-        return done(null, {
+        done(null, {
             options: {
                 middleware: bs.pluginManager.hook(
                     "server:middleware",
@@ -196,11 +196,10 @@ module.exports = {
      * be live updated inside resp-modifier/foxy
      * @param bs
      * @param done
-     * @returns {*}
      */
     setUserRewriteRules: function (bs, done) {
         var userRules = bs.options.get("rewriteRules");
-        return done(null, {
+        done(null, {
             instance: {
                 rewriteRules: userRules ? userRules.toJS() : []
             }


### PR DESCRIPTION
Return value of `mergeMiddlewares` and `setUserRewriteRules` is not used at [here](https://github.com/BrowserSync/browser-sync/blob/f80feb7c8fa0efffd7b70462cee34274483d4dc8/lib/browser-sync.js#L149).