### PR TITLE
Adds support for bodyparser configuration on static server

### DIFF
--- a/lib/server/static-server.js
+++ b/lib/server/static-server.js
@@ -26,14 +26,14 @@ module.exports = function createServer (bs, scripts) {
 	/**
 	 * Support bodyparser
 	 */
-	var bodyParserOptions = server.get("bodyParser");
+    var bodyParserOptions = server.get("bodyParser");
     if (bodyParserOptions) {
-      var bodyParser = require('body-parser');
-      var options = bodyParserOptions.toJS();
+        var bodyParser = require("body-parser");
+        var options = bodyParserOptions.toJS();
 
-      for (var parser in options) {
-        app.use(bodyParser[parser](options[parser]));
-      }
+        for (var parser in options) {
+            app.use(bodyParser[parser](options[parser]));
+        }
     }
 	
     /**

--- a/lib/server/static-server.js
+++ b/lib/server/static-server.js
@@ -23,6 +23,19 @@ module.exports = function createServer (bs, scripts) {
      */
     app.use(utils.handleOldIE);
 
+	/**
+	 * Support bodyparser
+	 */
+	var bodyParserOptions = server.get("bodyParser");
+    if (bodyParserOptions) {
+      var bodyParser = require('body-parser');
+      var options = bodyParserOptions.toJS();
+
+      for (var parser in options) {
+        app.use(bodyParser[parser](options[parser]));
+      }
+    }
+	
     /**
      * Serve the Client-side JS from both version and static paths
      */


### PR DESCRIPTION
in order to implement a custom API server through browsersyncs middleware it would be nice to access POST data with the bodyparser.

Usage:
```js
browserSync({
    open: false,
    port: 9000,
    server: {
      baseDir: ['.'],
      bodyParser: {
        json: {limit: '50mb'},
        urlencoded: { extended: true, limit: '50mb' }
      },
      middleware: function (req, res, next) {

        res.setHeader('Access-Control-Allow-Origin', '*');

        if (req.url.match(/^.*\/api\/.*/)) {
          console.log('API request');

          // access post body payload
          console.log(req.body);
        }

        next();
      }
    }
```