### PR TITLE
Update Travis CI to test latest NodeJS versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ git:
   depth: 2
 language: node_js
 node_js:
-  - node
+  - "5.3"
+  - "4.2"
   - '0.10'
 after_script: npm run cover


### PR DESCRIPTION
Updates Travis CI testing matrix to use the latest NodeJS 4.x and 5.x branches which are `4.2.x` and `5.3.x` respectively, the previous alias `node` would only test against `4.0.0`