### PR TITLE
docs: Add middleware option comment

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,7 +1,7 @@
 root = true
 
 [*]
-charset = utf8
+charset = utf-8
 end_of_line = lf
 indent_style = space
 indent_size = 2

--- a/lib/default-config.js
+++ b/lib/default-config.js
@@ -86,6 +86,11 @@ module.exports = {
      */
     port: 3000,
 
+    /**
+     * @property middleware
+     * @type Function|Array
+     * @default false
+     */
     middleware: false,
 
     /**


### PR DESCRIPTION
Add middleware comment so it will be listed in the options documentation:
https://browsersync.io/docs/options/

Change the .editorconfig charset from utf8 to utf-8 because my editor identified the current value as invalid:
http://docs.editorconfig.org/en/master/editorconfig-format.html