### PR TITLE
#970 Fix: Change SHA-1 to SHA-256 cert

### DIFF
--- a/lib/server/certs/gen.sh
+++ b/lib/server/certs/gen.sh
@@ -1,4 +1,4 @@
-openssl genrsa -des3 -out server.key 1024
+openssl genrsa -des3 -out server.key 2048
 openssl req -new -key server.key -out server.csr
 openssl x509 -req -days 3650 -in server.csr -signkey server.key -out server.crt
 cp server.key server.key.copy


### PR DESCRIPTION
If necessary we can easily change to SHA-512: http://itigloo.com/security/generate-an-openssl-certificate-request-with-sha-256-signature/
