### PR TITLE
Simplify script tags template

### DIFF
--- a/lib/templates/script-tags.tmpl
+++ b/lib/templates/script-tags.tmpl
@@ -1,3 +1,3 @@
-<script type='text/javascript' id="__bs_script__">//<![CDATA[
+<script id="__bs_script__">//<![CDATA[
     document.write("<script %async% src='%script%'><\/script>".replace("HOST", location.hostname));
 //]]></script>


### PR DESCRIPTION
`type=text/javascript` is the implied default; there is no reason to include it.

https://mathiasbynens.be/notes/html5-levels#level-1