### PR TITLE
configurable static path

### DIFF
--- a/lib/async.js
+++ b/lib/async.js
@@ -252,7 +252,11 @@ module.exports = {
         bs.options
             .get("serveStatic")
             .forEach(function (dir) {
-                bs.addMiddleware("*", utils.serveStatic(dir));
+                if (_.isString(dir)) {
+                    bs.addMiddleware("*", utils.serveStatic(dir));
+                } else {
+                    bs.addMiddleware(dir.get(0), utils.serveStatic(dir.get(1)));
+                }
             });
         done();
     },


### PR DESCRIPTION
This PR make possible path mapping for static serving, for example:

```js
var browserSyncDistOptions = {
    proxy: process.env.TARGET_URL,
    serveStatic: [['/app1','./dist/'], ['/app2','./test']]
};

// old config is also supported:
var browserSyncOptions = {
    proxy: process.env.TARGET_URL,
    serveStatic: ['.']
};
```