### PR TITLE
Add CA and Passphrase for custom HTTPS

### DIFF
--- a/lib/server/utils.js
+++ b/lib/server/utils.js
@@ -16,7 +16,9 @@ var utils = {
     getKeyAndCert: function (options) {
         return {
             key:  fs.readFileSync(options.getIn(["https", "key"])  || filePath.join(__dirname, "certs/server.key")),
-            cert: fs.readFileSync(options.getIn(["https", "cert"]) || filePath.join(__dirname, "certs/server.crt"))
+            cert: fs.readFileSync(options.getIn(["https", "cert"]) || filePath.join(__dirname, "certs/server.crt")),
+            ca: fs.readFileSync(options.getIn(["https", "ca"]) || filePath.join(__dirname, "certs/server.csr")),
+            passphrase: options.getIn(["https", "passphrase"]) || ''
         };
     },
     /**


### PR DESCRIPTION
Since there are just two options for HTTPS, I cannot test by using my own customized SSL certification. So I add two more options: CA and passphrase. 

Using these two options (gulpfile.js for example):

```js
https: {
            key: 'cert/www_abc_com.pem',
            cert: 'cert/www_abc_com.crt',
            **ca: 'cert/DigiCertCA.crt',
            passphrase: '12345qwert!1'**
        }
```