### PR TITLE
Update logo path in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
  <img src="https://img.shields.io/david/dev/Browsersync/browser-sync.svg?style=flat-square&label=devDeps" />
 </a>
 </p>
-<p align="center"><a href="http://www.browsersync.io"><img src="https://raw.githubusercontent.com/BrowserSync/browsersync.github.io/master/img/logo-gh.png" /></a></p>
+<p align="center"><a href="http://www.browsersync.io"><img src="https://raw.githubusercontent.com/BrowserSync/browsersync.github.io/master/public/img/logo-gh.png" /></a></p>
 <p align="center">Keep multiple browsers & devices in sync when building websites.</p>
 
 <p align="center">Browsersync is developed and maintained internally at <a href="http://www.wearejh.com">JH</a></p>


### PR DESCRIPTION
The logo is missing on GH page as the path has changed.

<img width="995" alt="screen shot 2016-08-11 at 10 55 29" src="https://cloud.githubusercontent.com/assets/68341/17583642/37a5b51e-5fb2-11e6-8fe7-b8ba101aa00d.png">
