### PR TITLE
support opn's options for loading a browser with arguments

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -165,13 +165,23 @@ var utils = {
             }
         }
     },
+
+    // https://browsersync.io/docs/options
+    //https://www.npmjs.com/package/opn
+    //
     /**
      * Wrapper for open module - for easier stubbin'
      * @param url
-     * @param name
+     * @param browser
      */
-    open: function (url, name) {
-        require("opn")(url, {app: name || null});
+    open: function (url, browser) {
+        var options = null;
+        if(_.isString(browser)) {
+            options = {app: browser};
+        } else if(Immutable.Map.isMap(browser)) {
+            options = {app: browser.toJS().app};
+        }
+        require("opn")(url, options);
     },
     /**
      * @param {Boolean} kill


### PR DESCRIPTION
eg: 


```
gulp.task('serve', function() {
	browserSync({
		files: [
			path.join('.tmp', config.contentFolder, '**/*')
		],
        browser:
        {
        	app: [
        		'chromium-browser',
        		'--app=http://localhost:8080',
        		'--proxy-server=localhost:8080',
        		'--user-data-dir=.tmp/chomium'
    		]
    	},
		port: 8080,
});
```