### PR TITLE
#1151 Fix regex of 'rewriteLinks'

### DIFF
--- a/lib/server/proxy-utils.js
+++ b/lib/server/proxy-utils.js
@@ -13,10 +13,10 @@ module.exports.rewriteLinks = function (userServer) {
     }
 
     return {
-        match: new RegExp("https?:\\\\/\\\\/" + string + "|('|\")\\\/\\\/" + string + "|https?://" + string + "(\/)?|('|\")(https?://|/|\\.)?" + string + "(\/)?(.*?)(?=[ ,'\"\\s])", "g"),
-        //match: new RegExp("https?:\\\\/\\\\/" + string + "|https?://" + string + "(\/)?|('|\")(https?://|/|\\.)?" + string + "(\/)?(.*?)(?=[ ,'\"\\s])", "g"),
-        //match: new RegExp("https?:\\\\?/\\\\?/" + string + "(\/)?|('|\")(https?://|\\\\?/|\\.)?" + string + "(\/)?(.*?)(?=[ ,'\"\\s])", "g"),
-        //match: new RegExp('https?://' + string + '(\/)?|(\'|")(https?://|/|\\.)?' + string + '(\/)?(.*?)(?=[ ,\'"\\s])', 'g'),
+        match: new RegExp("https?:\\\\/\\\\/" + string + "|('|\")\\\/\\\/" + string + "|https?://" + string + "(\/)?|('|\")(https?://|/|\\.)?" + string + "(\/.*?)?(?=[ ,'\"\\s])", "g"),
+        //match: new RegExp("https?:\\\\/\\\\/" + string + "|https?://" + string + "(\/)?|('|\")(https?://|/|\\.)?" + string + "(\/.*?)?(?=[ ,'\"\\s])", "g"),
+        //match: new RegExp("https?:\\\\?/\\\\?/" + string + "(\/)?|('|\")(https?://|\\\\?/|\\.)?" + string + "(\/.*?)?(?=[ ,'\"\\s])", "g"),
+        //match: new RegExp('https?://' + string + '(\/)?|(\'|")(https?://|/|\\.)?' + string + '(\/.*?)?(?=[ ,\'"\\s])', 'g'),
         //match: new RegExp("https?:\\\\/\\\\/" + string, "g"),
         fn:    function (req, res, match) {
 

--- a/test/specs/resp-mod/rewrite-links.js
+++ b/test/specs/resp-mod/rewrite-links.js
@@ -143,6 +143,11 @@ describe("Rewriting Domains", function() {
             var actual   = input.replace(rewrite.match, bound);
             assert.equal(actual, expected);
         });
+        it("should use the regex to replace links that URL format only", function() {
+            var input = testRegex('[0 => \\"http://localhost:8000\\",\\n 1 => \\"//localhost:8000\\"\\n]');
+            var actual = '[0 => \\"//192.168.0.4:3002\\",\\n 1 => \\"//192.168.0.4:3002\\"\\n]';
+            assert.equal(actual, input);
+        });
         it("should use the regex to replace links that contain port + ", function() {
             var input = '<!--//<a href="http://example.com:1234/foo">Link 1</a>--><a href="http://example.com.gov/foo">Link 1</a>';
             var expected = '<!--//<a href="//192.168.0.4:3002/foo">Link 1</a>--><a href="http://example.com.gov/foo">Link 1</a>';


### PR DESCRIPTION
Response body: `[0 => \"http://localhost:8000\",\n 1 => \"//localhost:8000\"\n]`
Rewriting options: `utils.rewriteLinks({hostname: "localhost:8000"}, "localhost:3000")`

Current: `[0 => \"http://localhost:3000",\n 1 => \"//localhost:3000"\n]`
Fixed: `[0 => \"http://localhost:3000\",\n 1 => \"//localhost:3000\"\n]`