### PR TITLE
fix: https config is overridden by flag

### DIFF
--- a/lib/cli/command.start.js
+++ b/lib/cli/command.start.js
@@ -25,6 +25,7 @@ module.exports = function (opts) {
         var maybeconf = path.resolve(process.cwd(), flags.config);
         if (fs.existsSync(maybeconf)) {
             var conf = require(maybeconf);
+            if (flags.https === null) { delete flags.https; }
             input = _.merge({}, conf, flags);
         } else {
             utils.fail(true, new Error("Configuration file '" + flags.config + "' not found"), opts.cb);

--- a/lib/cli/opts.start.json
+++ b/lib/cli/opts.start.json
@@ -49,6 +49,7 @@
   },
   "https": {
     "type": "boolean",
+    "default": null,
     "desc": "Enable SSL for local development"
   },
   "directory": {


### PR DESCRIPTION
Fixes https://github.com/BrowserSync/browser-sync/issues/1211

Probably not the cleanest solution