### PR TITLE
Fix custom middleware not working on proxy mode

### DIFF
--- a/lib/browser-sync.js
+++ b/lib/browser-sync.js
@@ -424,7 +424,7 @@ BrowserSync.prototype.addMiddleware = function (route, handle, opts) {
     }
 
     bs.options = bs.options.update("middleware", function (mw) {
-        return mw.concat(entry);
+        return (bs.options.get("mode") === "proxy")? mw.insert(mw.size-1, entry) : mw.concat(entry);
     });
 
     bs.resetMiddlewareStack();


### PR DESCRIPTION
Hello, looks like middleware was rewritten recently. It's broken third party plugins which use custom middleware. 

It should meet two requirements.

1. in proxy mode
2. use custom middleware.

The reason is "Browsersync Proxy" middleware added before any custom middleware. So it will block any following middleware which add later. 

The updating should fix this issue. Let me know if you have any questions.

Thank you

