### PR TITLE
Allow users to override default httpModule

### DIFF
--- a/examples/server.http2.js
+++ b/examples/server.http2.js
@@ -1,0 +1,25 @@
+/**
+ *
+ * Install:
+ *      npm install browser-sync http2
+ *
+ * Run:
+ *      node <yourfile.js>
+ *
+ * This example will create a server using http2 using the default information & use the `app` directory as the root
+ *
+ */
+
+"use strict";
+
+var http2 = require("http2");
+var browserSync = require("browser-sync").create();
+
+browserSync.init({
+    files: ["app/css/*.css"],
+    server: {
+        baseDir: "app"
+    },
+    https: true,
+    httpModule: http2
+});

--- a/lib/default-config.js
+++ b/lib/default-config.js
@@ -125,6 +125,14 @@ module.exports = {
      */
 
     /**
+     * Override http module to allow using 3rd party server modules (such as http2)
+     * @property httpModule
+     * @type Object|Function
+     * @default undefined
+     * @since 2.17.6
+     */    
+
+    /**
      * Clicks, Scrolls & Form inputs on any device will be mirrored to all others.
      * @property ghostMode
      * @param {Boolean} [clicks=true]

--- a/lib/public/init.js
+++ b/lib/public/init.js
@@ -27,6 +27,16 @@ module.exports = function (browserSync, name, pjson) {
 
         args.config.version = pjson.version;
 
+        /**
+         * Preserve the httpModule property's functions.
+         * the http2 module exports an object of functions and the merge function seems
+         * to want to destroy that, but if the base object is a function it seems fine
+         * TODO: find a better or more generic way to handle this
+         */
+        if(args.config.httpModule && !_.isFunction(args.config.httpModule)) {
+            args.config.httpModule = Object.assign(function() {}, args.config.httpModule);
+        }
+
         return browserSync.init(merge(args.config), args.cb);
     };
 };

--- a/lib/server/utils.js
+++ b/lib/server/utils.js
@@ -40,18 +40,21 @@ var serverUtils = {
         };
     },
     /**
-     * Get either an http or https server
+     * Get either http or https server
+     * or use the httpModule provided in options if present
      */
     getServer: function (app, options) {
         return {
             server: (function () {
+                var httpModule = options.get("httpModule") || (options.get("scheme") === "https" ? https : http);
+
                 if (options.get("scheme") === "https") {
                     var pfxPath = options.getIn(["https", "pfx"]);
                     return pfxPath ?
-                        https.createServer(serverUtils.getPFX(pfxPath), app) :
-                        https.createServer(serverUtils.getKeyAndCert(options), app);
+                        httpModule.createServer(serverUtils.getPFX(pfxPath), app) :
+                        httpModule.createServer(serverUtils.getKeyAndCert(options), app);
                 }
-                return http.createServer(app);
+                return httpModule.createServer(app);
             })(),
             app: app
         };

--- a/test/specs/e2e/server/e2e.server.httpModule.js
+++ b/test/specs/e2e/server/e2e.server.httpModule.js
@@ -1,0 +1,96 @@
+"use strict";
+
+var browserSync = require("../../../../index");
+
+var assert = require("chai").assert;
+var sinon = require("sinon");
+
+describe("E2E httpModule options test", function () {
+
+    this.timeout(15000);
+
+    var bs;
+    var mockHttpModule, mockHttpServer, createServerSpy, https;
+
+    describe("httpModule undefined", function () {
+
+        before(function (done) {
+
+            browserSync.reset();
+            https = require("https");
+            
+            createServerSpy = sinon.spy(https, "createServer");
+
+            var config = {
+                server:    {
+                    baseDir: "test/fixtures",
+                },
+                https: true,
+                open: false,
+                logLevel: "silent"
+            };
+
+            bs = browserSync.init(config, done).instance;
+        });
+
+        after(function () {
+            bs.cleanup();
+        });
+
+        it("creates server using the default https module", function () {
+            sinon.assert.calledOnce(createServerSpy);
+        });
+
+        it("should be using the server from the https module", function () {
+            assert.equal(bs.server instanceof https.Server, true);
+        });        
+    });
+
+    describe("httpModule defined", function () {
+
+        before(function (done) {
+
+            browserSync.reset();
+
+            mockHttpServer = {
+                on: function() { },
+                listen: function() { },
+                listeners: function() { return []; },
+                removeAllListeners: function() { },
+                close: function() { }
+            };
+
+            mockHttpModule = {
+                createServer: function() {
+                    return mockHttpServer;
+                }
+            };
+
+            createServerSpy = sinon.spy(mockHttpModule, "createServer");
+
+            var config = {
+                server:    {
+                    baseDir: "test/fixtures",
+                },
+                https: true,
+                httpModule: mockHttpModule,
+                open: false,
+                logLevel: "silent"
+            };
+
+            bs = browserSync.init(config, done).instance;
+        });
+
+        after(function () {
+            bs.cleanup();
+        });
+
+        it("creates server using provided httpModule", function () {
+            sinon.assert.calledOnce(createServerSpy);
+        });
+
+        it("should be using the server created by the provided httpModule", function () {
+            assert.equal(bs.server, mockHttpServer);
+        });
+    });
+});


### PR DESCRIPTION
This change allows a user to provide any httpModule as an option in the init function. The provided httpModule will be used in place of the http / https module. The main purpose of this update is to allow using [node-http2](https://github.com/molnarg/node-http2) which is a drop in http2 replacement for the standard node https module.

This solution is an alternative to [PR 1150](https://github.com/BrowserSync/browser-sync/pull/1150) that I think provides a couple advantages:

- Doesn't break existing users (unless the httpModule property is used nothing changes)
- Solves the problem in a more generic way by allowing the user to specify the override
- Doesn't add the http2 module as a dependency (users that don't use it shouldn't need to download it)

Closes #766 