### PR TITLE
Portscanner last correct version

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "localtunnel": "1.8.2",
     "micromatch": "2.3.11",
     "opn": "4.0.2",
-    "portscanner": "^1.0.0",
+    "portscanner": "1.0.0",
     "qs": "6.2.1",
     "resp-modifier": "6.0.2",
     "rx": "4.1.0",


### PR DESCRIPTION
We have error while starting browsersync problem we get from Portscanner. If we use version 1.0.0 problem disappears.