### PR TITLE
Fix runtime error when value is undefined

### DIFF
--- a/lib/browser-sync.js
+++ b/lib/browser-sync.js
@@ -541,7 +541,9 @@ BrowserSync.prototype.setOption = function (name, value, opts) {
 
     opts = opts || {};
 
-    bs.debug("Setting Option: {cyan:%s} - {magenta:%s", name, value.toString());
+    if (value && value.toString) {
+        bs.debug("Setting Option: {cyan:%s} - {magenta:%s", name, value.toString());
+    }
 
     bs.options = bs.options.set(name, value);
 


### PR DESCRIPTION
I had this error on Ubuntu 16.10, node 7.5, browser-sync ^2.18.5

```
TypeError: Cannot read property 'toString' of undefined
    at BrowserSync.setOption (****/node_modules/browser-sync/lib/browser-sync.js:544:14)
    at ****/node_modules/browser-sync/lib/browser-sync.js:226:16
    at Array.forEach (native)
    at setOptions (****/node_modules/browser-sync/lib/browser-sync.js:225:30)
    at handleOut (****/node_modules/browser-sync/lib/browser-sync.js:184:9)
    at executeTask (****/node_modules/browser-sync/lib/browser-sync.js:165:17)
    at ****/node_modules/browser-sync/lib/async.js:24:13
    at ****/node_modules/portscanner/lib/portscanner.js:222:7
    at ****/node_modules/portscanner/node_modules/async/lib/async.js:789:30
    at ****/node_modules/portscanner/node_modules/async/lib/async.js:167:37
```