### PR TITLE
use explicit protocol when replacing links in documents from proxies

### DIFF
--- a/packages/browser-sync/lib/server/proxy-utils.js
+++ b/packages/browser-sync/lib/server/proxy-utils.js
@@ -1,7 +1,9 @@
 var url = require("url");
 
-module.exports.rewriteLinks = function(userServer) {
-    var host = userServer.hostname;
+module.exports.rewriteLinks = function (userServer) {
+
+    var proto  = userServer.protocol || ""; // example "https:"
+    var host   = userServer.hostname;
     var string = host;
     var port = userServer.port;
 
@@ -91,6 +93,7 @@ module.exports.rewriteLinks = function(userServer) {
              */
             return [
                 captured,
+                proto,
                 pre,
                 proxyUrl,
                 out.path || "",

--- a/packages/browser-sync/lib/server/proxy-utils.js
+++ b/packages/browser-sync/lib/server/proxy-utils.js
@@ -1,9 +1,8 @@
 var url = require("url");
 
-module.exports.rewriteLinks = function (userServer) {
-
-    var proto  = userServer.protocol || ""; // example "https:"
-    var host   = userServer.hostname;
+module.exports.rewriteLinks = function(userServer) {
+    var proto = userServer.protocol || ""; // example "https:"
+    var host = userServer.hostname;
     var string = host;
     var port = userServer.port;
 
@@ -15,7 +14,8 @@ module.exports.rewriteLinks = function (userServer) {
 
     var reg = new RegExp(
         // a simple, but exact match
-        "https?:\\\\/\\\\/" +
+        proto +
+            "\\\\/\\\\/" +
             string +
             "|" +
             // following ['"] + exact
@@ -23,12 +23,15 @@ module.exports.rewriteLinks = function (userServer) {
             string +
             "|" +
             // exact match with optional trailing slash
-            "https?://" +
+            proto +
+            "//" +
             string +
             "(?!:)(/)?" +
             "|" +
             // following ['"] + exact + possible multiple (imr srcset etc)
-            "('|\")(https?://|/|\\.)?" +
+            "('|\")(" +
+            proto +
+            "//|/|\\.)?" +
             string +
             "(?!:)(/)?(.*?)(?=[ ,'\"\\s])",
         "g"

--- a/packages/browser-sync/test/fixtures/rewrites/comment.expected.html
+++ b/packages/browser-sync/test/fixtures/rewrites/comment.expected.html
@@ -3,5 +3,5 @@
 <p>This is an experiment.dev</p>
 <p><img src="/images/experiment.dev/example.jpg"></p>
 <!-- This experiment.dev should prove interesting -->
-<p><a href="//192.168.0.4:3002/example.html">Link</a></p>
+<p><a href="http://192.168.0.4:3002/example.html">Link</a></p>
 </body></html>

--- a/packages/browser-sync/test/fixtures/rewrites/escaped.1.expected.html
+++ b/packages/browser-sync/test/fixtures/rewrites/escaped.1.expected.html
@@ -1,2 +1,2 @@
-<a href="//192.168.0.4:3002"></a>
+<a href="http://192.168.0.4:3002"></a>
 phpdebugbar.setOpenHandler(new PhpDebugBar.OpenHandler({"url":"http:\/\/192.168.0.4:3002\/_debugbar\/open"}));

--- a/packages/browser-sync/test/fixtures/rewrites/hashes.expected.html
+++ b/packages/browser-sync/test/fixtures/rewrites/hashes.expected.html
@@ -1,20 +1,20 @@
 <ul class="navigation__items">
   <li class="navigation__items__page">
-    <a href="//192.168.0.4:3002/careers/?number=4">« Previous</a>
+    <a href="http://192.168.0.4:3002/careers/?number=4">« Previous</a>
   </li>
   <li class="navigation__items__page">
-    <a href="//192.168.0.4:3002/careers/#search">1</a>
+    <a href="http://192.168.0.4:3002/careers/#search">1</a>
   </li>
   <li class="navigation__items__page">
-    <a href="//192.168.0.4:3002/careers/?number=2#search">2</a>
+    <a href="http://192.168.0.4:3002/careers/?number=2#search">2</a>
   </li>
   <li class="navigation__items__page">
-    <a href="//192.168.0.4:3002/careers/?number=3#search">3</a>
+    <a href="http://192.168.0.4:3002/careers/?number=3#search">3</a>
   </li>
   <li class="navigation__items__page">
-    <a href="//192.168.0.4:3002/careers/?number=4#search">4</a>
+    <a href="http://192.168.0.4:3002/careers/?number=4#search">4</a>
   </li>
   <li class="navigation__items__page navigation__items__page--active">
-    <a href="//192.168.0.4:3002/careers/?number=5#search">5</a>
+    <a href="http://192.168.0.4:3002/careers/?number=5#search">5</a>
   </li>
 </ul>

--- a/packages/browser-sync/test/specs/e2e/proxy/e2e.proxy.rewrite.rules.add.js
+++ b/packages/browser-sync/test/specs/e2e/proxy/e2e.proxy.rewrite.rules.add.js
@@ -39,7 +39,7 @@ describe("E2E proxy test with adding rewrite rules dynamically", function() {
                 [
                     [
                         "/index.html",
-                        '<a href="//127.0.0.1:3000/my-link">BROWSERSYNC</a>'
+                        '<a href="http://127.0.0.1:3000/my-link">BROWSERSYNC</a>'
                     ]
                 ],
                 bs.server
@@ -86,7 +86,7 @@ describe("E2E proxy test with adding rewrite rules dynamically", function() {
                 [
                     [
                         "/index.html",
-                        '<a href="//127.0.0.1:3000/my-link">BROWSERSYNC</a>'
+                        '<a href="http://127.0.0.1:3000/my-link">BROWSERSYNC</a>'
                     ],
                     function() {
                         bs.addRewriteRule({
@@ -97,14 +97,14 @@ describe("E2E proxy test with adding rewrite rules dynamically", function() {
                     },
                     [
                         "/index.html",
-                        '<a href="//127.0.0.1:3000/my-link">shane</a>'
+                        '<a href="http://127.0.0.1:3000/my-link">shane</a>'
                     ],
                     function() {
                         bs.removeRewriteRule("my-rewrite-rule");
                     },
                     [
                         "/index.html",
-                        '<a href="//127.0.0.1:3000/my-link">BROWSERSYNC</a>'
+                        '<a href="http://127.0.0.1:3000/my-link">BROWSERSYNC</a>'
                     ]
                 ],
                 bs.server

--- a/packages/browser-sync/test/specs/resp-mod/rewrite-links.js
+++ b/packages/browser-sync/test/specs/resp-mod/rewrite-links.js
@@ -32,29 +32,29 @@ describe("Rewriting Domains", function() {
                 "<link href='http://example.com/css/styles'>example.com</link>"
             );
             var expected =
-                "<link href='//192.168.0.4:3002/css/styles'>example.com</link>";
+                "<link href='http://192.168.0.4:3002/css/styles'>example.com</link>";
             assert.equal(actual, expected);
         });
         it("should use the regex to replace links (2)", function() {
             var actual = testRegex("<a href='http://example.com'></a>");
-            var expected = "<a href='//192.168.0.4:3002'></a>";
+            var expected = "<a href='http://192.168.0.4:3002'></a>";
             assert.equal(actual, expected);
         });
         it("should use the regex to replace links (23)", function() {
             var actual = testRegex("<a href='http://example.com/sub/dir'></a>");
-            var expected = "<a href='//192.168.0.4:3002/sub/dir'></a>";
+            var expected = "<a href='http://192.168.0.4:3002/sub/dir'></a>";
             assert.equal(actual, expected);
         });
         it("should use the regex to replace links (3)", function() {
             var actual = testRegex("<a href='http://example.com/sub/dir'></a>");
-            var expected = "<a href='//192.168.0.4:3002/sub/dir'></a>";
+            var expected = "<a href='http://192.168.0.4:3002/sub/dir'></a>";
             assert.equal(actual, expected);
         });
         it("should use the regex to replace links (4)", function() {
             var actual = testRegex(
                 "<a href='https://example.com/sub/dir'></a>"
             );
-            var expected = "<a href='//192.168.0.4:3002/sub/dir'></a>";
+            var expected = "<a href='https://192.168.0.4:3002/sub/dir'></a>";
             assert.equal(actual, expected);
         });
         it("should use the regex to replace links (5)", function() {
@@ -73,7 +73,7 @@ describe("Rewriting Domains", function() {
                 '<a href="http://example.com" class="active" title="Home">Home</a><a href="http://example.com/information" class="" title="Info">Info</a>'
             );
             var expected =
-                '<a href="//192.168.0.4:3002" class="active" title="Home">Home</a><a href="//192.168.0.4:3002/information" class="" title="Info">Info</a>';
+                '<a href="http://192.168.0.4:3002" class="active" title="Home">Home</a><a href="http://192.168.0.4:3002/information" class="" title="Info">Info</a>';
             assert.equal(actual, expected);
             /*jshint ignore:end*/
         });
@@ -82,7 +82,7 @@ describe("Rewriting Domains", function() {
                 "<a href='http://example.com/sub/dir/example.com/css/styles.css'></a><a href='http://example.com/sub/dir/example.com/css/styles.css'></a>"
             );
             var expected =
-                "<a href='//192.168.0.4:3002/sub/dir/example.com/css/styles.css'></a><a href='//192.168.0.4:3002/sub/dir/example.com/css/styles.css'></a>";
+                "<a href='http://192.168.0.4:3002/sub/dir/example.com/css/styles.css'></a><a href='http://192.168.0.4:3002/sub/dir/example.com/css/styles.css'></a>";
             assert.equal(actual, expected);
         });
     });
@@ -104,33 +104,33 @@ describe("Rewriting Domains", function() {
         });
         it("should use the regex to replace links (1)", function() {
             var actual = testRegex("<a href='http://localhost:8000'></a>");
-            var expected = "<a href='//192.168.0.4:3002'></a>";
+            var expected = "<a href='http://192.168.0.4:3002'></a>";
             assert.equal(actual, expected);
         });
         it("should use the regex to replace links (1)", function() {
             var actual = testRegex("<a href='http://localhost:8000'></a>");
-            var expected = "<a href='//192.168.0.4:3002'></a>";
+            var expected = "<a href='http://192.168.0.4:3002'></a>";
             assert.equal(actual, expected);
         });
         it("should use the regex to replace links (2)", function() {
             var actual = testRegex(
                 "<a href='http://localhost:8000/sub/dir'></a>"
             );
-            var expected = "<a href='//192.168.0.4:3002/sub/dir'></a>";
+            var expected = "<a href='http://192.168.0.4:3002/sub/dir'></a>";
             assert.equal(actual, expected);
         });
         it("should use the regex to replace links (3)", function() {
             var actual = testRegex(
                 "<a href='http://localhost:8000/sub/dir'></a>"
             );
-            var expected = "<a href='//192.168.0.4:3002/sub/dir'></a>";
+            var expected = "<a href='http://192.168.0.4:3002/sub/dir'></a>";
             assert.equal(actual, expected);
         });
         it("should use the regex to replace links (4)", function() {
             var actual = testRegex(
                 "<a href='https://localhost:8000/sub/dir'></a>"
             );
-            var expected = "<a href='//192.168.0.4:3002/sub/dir'></a>";
+            var expected = "<a href='https://192.168.0.4:3002/sub/dir'></a>";
             assert.equal(actual, expected);
         });
         it("should use the regex to replace links (5)", function() {
@@ -148,14 +148,15 @@ describe("Rewriting Domains", function() {
                 "<a href='http://localhost:8000/sub/dir/?search=some#shane'></a>"
             );
             var expected =
-                "<a href='//192.168.0.4:3002/sub/dir/?search=some#shane'></a>";
+                "<a href='http://192.168.0.4:3002/sub/dir/?search=some#shane'></a>";
             assert.equal(actual, expected);
         });
         it("should use the regex to replace links that contain hashes (2)", function() {
             var actual = testRegex(
                 "<a href='http://localhost:8000/sub/dir/#search'></a>"
             );
-            var expected = "<a href='//192.168.0.4:3002/sub/dir/#search'></a>";
+            var expected =
+                "<a href='http://192.168.0.4:3002/sub/dir/#search'></a>";
             assert.equal(actual, expected);
         });
         it("should use the regex to replace links that contain hashes (2)", function() {
@@ -183,7 +184,7 @@ describe("Rewriting Domains", function() {
             var input =
                 '<!--//<a href="http://example.com:1234/foo">Link 1</a>--><a href="http://example.com.gov/foo">Link 1</a>';
             var expected =
-                '<!--//<a href="//192.168.0.4:3002/foo">Link 1</a>--><a href="http://example.com.gov/foo">Link 1</a>';
+                '<!--//<a href="http://192.168.0.4:3002/foo">Link 1</a>--><a href="http://example.com.gov/foo">Link 1</a>';
 
             var rewrite = utils.rewriteLinks(
                 { hostname: "example.com", port: 1234 },
@@ -261,7 +262,7 @@ describe("Rewriting Domains", function() {
         });
         it("should not remove trailing slash", function() {
             var input = '<a href="http://example.com:1234/foo/">Link 1</a>';
-            var expected = '<a href="//' + proxyUrl + '/foo/">Link 1</a>';
+            var expected = '<a href="http://' + proxyUrl + '/foo/">Link 1</a>';
             var rewrite = utils.rewriteLinks(
                 { hostname: "example.com", port: 1234 },
                 proxyUrl
@@ -278,9 +279,9 @@ describe("Rewriting Domains", function() {
             var input =
                 '<a href="https://example.com/calendar/2015/06/24/20471/">https://example.com/calendar/2015/06/24/20471/</a></p></div></li></ol></td><td  class="cal-current-month">';
             var expected =
-                '<a href="//' +
+                '<a href="https://' +
                 proxyUrl +
-                '/calendar/2015/06/24/20471/">//' +
+                '/calendar/2015/06/24/20471/">https://' +
                 proxyUrl +
                 '/calendar/2015/06/24/20471/</a></p></div></li></ol></td><td  class="cal-current-month">';
             var rewrite = utils.rewriteLinks(
@@ -299,7 +300,7 @@ describe("Rewriting Domains", function() {
             var input =
                 '<a href="https://example.com/">https://example.com/</a></p></div></li></ol></td><td  class="cal-current-month">';
             var expected =
-                '<a href="//192.168.0.4:3002/">//192.168.0.4:3002/</a></p></div></li></ol></td><td  class="cal-current-month">';
+                '<a href="https://192.168.0.4:3002/">https://192.168.0.4:3002/</a></p></div></li></ol></td><td  class="cal-current-month">';
             var rewrite = utils.rewriteLinks(
                 { hostname: "example.com" },
                 proxyUrl
@@ -338,8 +339,8 @@ describe("Rewriting Domains", function() {
             `;
             var expected = `
                 <a href="http://localhost:6426">should skip</a>
-                <a href="//${proxyUrl}">should hit</a>
-                <a href="//${proxyUrl}/base.html">should hit (2)</a>
+                <a href="http://${proxyUrl}">should hit</a>
+                <a href="http://${proxyUrl}/base.html">should hit (2)</a>
             `;
             var rewrite = utils.rewriteLinks(
                 { hostname: "localhost" },
@@ -361,8 +362,8 @@ describe("Rewriting Domains", function() {
             `;
             var expected = `
                 <a href="http://localhost:6426">should skip</a>
-                <a href="//${proxyUrl}">should hit</a>
-                <a href="//${proxyUrl}/base.html">should hit (2)</a>
+                <a href="http://${proxyUrl}">should hit</a>
+                <a href="http://${proxyUrl}/base.html">should hit (2)</a>
             `;
             var rewrite = utils.rewriteLinks(
                 { hostname: "localhost", port: "8080" },


### PR DESCRIPTION
This is a change to how links are rewritten when proxying a site that serves responses on both "http" and "https" protocols but does not necessarily have functional consistency between the two. Specifically, all URL's that the proxy rewrites would include the protocol, rather than being protocol-relative. That is, they would start with "http://" or "https://" rather than "//". Rewritten links would always have the same protocol as the proxy target. This is mainly to solve an issue that I'm facing in the case of a proxied site has an inline script where it puts its full origin in a variable, which is subsequently used to construct API endpoints by JS functions whose parsing logic expects the URL in that variable to have an explicit protocol. In general, I suggest that explicit protocols in rewritten links is a functional improvement for the browser-sync proxy, because it avoids conflating protocols when proxying targets that are part of a dual-protocol site with protocol-specific functionality.