### PR TITLE
Improve documentation for steam

### DIFF
--- a/index.js
+++ b/index.js
@@ -102,6 +102,10 @@ module.exports.reload  = noop("reload");
  *
  * @method stream
  * @param {Object} [opts] Configuration for the stream method
+ * @param {Object} [opts.match] Resulting files to reload. The path is from the
+ * root of the site (not the root of your project).  You can use '**' to recurse
+ * directories.
+ * @param {Object} [opts.once] Only reload on the first changed file in teh stream.
  * @since 2.6.0
  * @returns {*}
  */


### PR DESCRIPTION
Explain the options you can pass into stream.

What to pass into `match` was causing me a lot of problems because I kept using `site/css/**/*.css` instead of just `css/**/*.css`; though I now realized that `**/*.css` would work fine too, since the stream only includes `css` files.

I wasn't sure to add something about `.map` files too...