### PR TITLE
feat: support custom local domain

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -53,6 +53,11 @@ var utils = {
 
         localhost = utils.xip(localhost, options);
 
+        var localDomain = options.get("localDomain");
+        if (localDomain) {
+            localhost = localDomain;
+        }
+
         return Immutable.fromJS(utils.getUrls(external, localhost, scheme, options));
     },
     /**

--- a/test/specs/e2e/e2e.options.js
+++ b/test/specs/e2e/e2e.options.js
@@ -239,4 +239,31 @@ describe("e2e options test", function () {
         });
         var bs = browserSync.init(["*.html"], {}).instance;
     });
+
+    it("Sets the local domain option", function (done) {
+        browserSync.reset();
+        var config = {
+            localDomain: "localhost.example.com"
+        };
+        browserSync(config, function (err, bs) {
+            assert.equal(bs.options.get("localDomain"), "localhost.example.com");
+            assert.ok(bs.options.getIn(["urls", "local"]).match(/http\:\/\/localhost.example.com:\d{4,5}$/));
+            bs.cleanup();
+            done();
+        });
+    });
+
+    it("Sets the local domain option with https", function (done) {
+        browserSync.reset();
+        var config = {
+            localDomain: "localhost.example.com",
+            https: true
+        };
+        browserSync(config, function (err, bs) {
+            assert.equal(bs.options.get("localDomain"), "localhost.example.com");
+            assert.ok(bs.options.getIn(["urls", "local"]).match(/https\:\/\/localhost.example.com:\d{4,5}$/));
+            bs.cleanup();
+            done();
+        });
+    });
 });


### PR DESCRIPTION
Adds support for an optional custom local domain, enabling use of domains other than "localhost", e.g. if you use a `/etc/hosts` file during local development, e.g. to allow cookies whose domains match higher environments. Will cause BrowserSync to open to this URL instead.