### PR TITLE
Fix tunnel issue

### DIFF
--- a/lib/internal-events.js
+++ b/lib/internal-events.js
@@ -14,20 +14,20 @@ module.exports = function (bs) {
          * @param data
          */
         "file:reload": function (data) {
-            bs.io.sockets.emit("file:reload", data);
+            bs.io && bs.io.sockets.emit("file:reload", data);
         },
         /**
          * Browser Reloads
          */
         "browser:reload": function () {
-            bs.io.sockets.emit("browser:reload");
+            bs.io && bs.io.sockets.emit("browser:reload");
         },
         /**
          * Browser Notify
          * @param data
          */
         "browser:notify": function (data) {
-            bs.io.sockets.emit("browser:notify", data);
+            bs.io && bs.io.sockets.emit("browser:notify", data);
         },
         /**
          * Things that happened after the service is running
@@ -52,9 +52,7 @@ module.exports = function (bs) {
          * @param data
          */
         "options:set": function (data) {
-            if (bs.io) {
-                bs.io.sockets.emit("options:set", data);
-            }
+            bs.io && bs.io.sockets.emit("options:set", data);
         },
         /**
          * Plugin configuration setting


### PR DESCRIPTION
Apparently BrowserSync tries to refresh the browser before `bs.io` is defined causing the following issues:

 - https://github.com/BrowserSync/browser-sync/issues/852
 - https://github.com/BrowserSync/browser-sync/issues/978

The issue happens when option `tunnel: true`

```js
bs.init({
    open: false,
    port: 3000,
    files:
    [ '/Users/mario.campa/stencil/templates',
        '/Users/mario.campa/stencil/lang' ],
    watchOptions:
    { ignoreInitial: true,
        ignored:
        [ '/Users/mario.campa/stencil/assets/scss',
            '/Users/mario.campa/stencil/assets/less',
            '/Users/mario.campa/stencil/assets/css',
            '/Users/mario.campa/stencil/assets/dist' ] },
    proxy: 'localhost:3001',
    tunnel: true,
});
```

```
/usr/local/lib/node_modules/browser-sync/node_modules/rx/dist/rx.js:77
    throw e;
    ^

TypeError: Cannot read property 'sockets' of undefined
    at EventEmitter.file:reload (/usr/local/lib/node_modules/browser-sync/lib/internal-events.js:17:18)
    at emitOne (events.js:101:20)
    at EventEmitter.emit (events.js:188:7)
    at /usr/local/lib/node_modules/browser-sync/lib/internal-events.js:100:35
    at Array.forEach (native)
    at AnonymousObserver._onNext (/usr/local/lib/node_modules/browser-sync/lib/internal-events.js:98:25)
    at AnonymousObserver.Rx.AnonymousObserver.AnonymousObserver.next (/usr/local/lib/node_modules/browser-sync/node_modules/rx/dist/rx.js:1828:12)
    at AnonymousObserver.Rx.internals.AbstractObserver.AbstractObserver.onNext (/usr/local/lib/node_modules/browser-sync/node_modules/rx/dist/rx.js:1762:31)
    at AnonymousObserver.tryCatcher (/usr/local/lib/node_modules/browser-sync/node_modules/rx/dist/rx.js:63:31)
    at AutoDetachObserverPrototype.next (/usr/local/lib/node_modules/browser-sync/node_modules/rx/dist/rx.js:5883:51)
```

This fixes the issue and the tunnel is started with no issues