### PR TITLE
Remove node-uuid deprecation warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "fs-extra": "3.0.1",
     "http-proxy": "1.15.2",
     "immutable": "3.8.1",
-    "localtunnel": "1.8.2",
+    "localtunnel": "1.8.3",
     "micromatch": "2.3.11",
     "opn": "4.0.2",
     "portscanner": "2.1.1",


### PR DESCRIPTION
### Problem

[node-uuid](https://www.npmjs.com/package/node-uuid), which browser-sync indirectly depends on, is deprecated. npm gives this warning during installations:

```shell
$ npm install
# ...
npm WARN deprecated node-uuid@1.4.8: Use uuid module instead
# ...
```

### Solution

browser-sync’s dependency [localtunnel](https://www.npmjs.com/package/localtunnel) depends on node-uuid:

```shell
$ npm ls node-uuid
# ...
├─┬ browser-sync@2.18.12
│ └─┬ localtunnel@1.8.2
│   └─┬ request@2.78.0
│     └── node-uuid@1.4.8  deduped
# ...
```

Fortunately, localtunnel@1.8.3 upgraded to [uuid](https://www.npmjs.com/package/uuid). Upgrading localtunnel in browser-sync fixes the problem.

### Testing

Running `npm test` yields:

```
  464 passing (9s)
  10 pending
```

🎉