### PR TITLE
Returned string is always true

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -147,7 +147,7 @@ var utils = {
         var browser = options.get("browser");
 
         if (_.isString(open)) {
-            if (options.getIn(["urls", open])) {
+            if (options.getIn(["urls", open]) && options.getIn(["urls", open]) !== 'false') {
                 url = options.getIn(["urls", open]);
             }
         }


### PR DESCRIPTION
When the user has no internet connection (wifi turned off for example) and the settings are set to open the external url, the line `options.getIn(["urls", open])` returns 'false' which makes browser-sync open http://false.