### PR TITLE
Adding options to http2 module

### DIFF
--- a/lib/server/utils.js
+++ b/lib/server/utils.js
@@ -84,7 +84,7 @@ var serverUtils = {
 
                 var httpModule = serverUtils.getHttpModule(options);
 
-                if (options.get("scheme") === "https") {
+                if (options.get("scheme") === "https"  || options.get("httpModule") === "http2") {
                     var opts = serverUtils.getHttpsOptions(options);
                     return httpModule.createServer(opts.toJS(), app);
                 }


### PR DESCRIPTION
http2 module require and options object with key and cert to run.
browser sync with http2 will also only work on port 443 or https.

Why I Made this pull request:
I was trying googles lighthouse audit tool and my app required my page to be served over http2 to pass the audit. I foud that browsersync could support httpd2 if i passed in the right configuration.
However browsersync crashed when tryin to launch the http2 server because it needs certificate and key options to be passed to it.