### PR TITLE
Made remote "notify" commands work

### DIFF
--- a/lib/public/notify.js
+++ b/lib/public/notify.js
@@ -4,12 +4,12 @@
  * @param {BrowserSync} browserSync
  * @returns {Function}
  */
-module.exports = function (browserSync) {
+module.exports = function (emitter) {
 
     return function (msg, timeout) {
 
         if (msg) {
-            browserSync.events.emit("browser:notify", {
+            emitter.emit("browser:notify", {
                 message: msg,
                 timeout: timeout || 2000,
                 override: true


### PR DESCRIPTION
The notifier command fails with a message that browserSync.events is undefined; this is because the commands receive the emitter as the parameter, not the browserSync instance.

At least this change makes it possible to have tools run things like

    curl 'http://localhost:3000/__browser_sync__?method=notify&args=Yeah<br><em>cool</em>!!'

:)