### PR TITLE
Fix the missing `type: array` in server field of startOpts

### DIFF
--- a/cli-options/opts.start.json
+++ b/cli-options/opts.start.json
@@ -1,5 +1,6 @@
 {
   "server": {
+    "type": "array",
     "alias": "s",
     "desc": "Run a Local server (uses your cwd as the web root)"
   },


### PR DESCRIPTION
```bash
browser-sync start --server app tmp
```

The above did not work properly. This PR fixed this issue.