### PR TITLE
Use the native http2 module in Node 9

### DIFF
--- a/lib/server/utils.js
+++ b/lib/server/utils.js
@@ -93,11 +93,11 @@ var serverUtils = {
                     options.get("httpModule") === "http2"
                 ) {
                     var opts = serverUtils.getHttpsOptions(options);
-                    
+
                     if (parseInt(process.versions.node.split(".")[0]) >= 9) {
-                        return httpModule.createSecureServer(opts.toJS(), app);   
+                        return httpModule.createSecureServer(opts.toJS(), app);
                     }
-                    
+
                     return httpModule.createServer(opts.toJS(), app);
                 }
 
@@ -112,9 +112,11 @@ var serverUtils = {
          * require lookup.
          */
         var httpModule = options.get("httpModule");
-        
-        if (httpModule === "http2" && 
-            parseInt(process.versions.node.split(".")[0]) >= 9) {
+
+        if (
+            httpModule === "http2" &&
+            parseInt(process.versions.node.split(".")[0]) >= 9
+        ) {
             return require("http2");
         }
 

--- a/lib/server/utils.js
+++ b/lib/server/utils.js
@@ -93,6 +93,11 @@ var serverUtils = {
                     options.get("httpModule") === "http2"
                 ) {
                     var opts = serverUtils.getHttpsOptions(options);
+                    
+                    if (parseInt(process.versions.node.split(".")[0]) >= 9) {
+                        return httpModule.createSecureServer(opts.toJS(), app);   
+                    }
+                    
                     return httpModule.createServer(opts.toJS(), app);
                 }
 
@@ -107,6 +112,11 @@ var serverUtils = {
          * require lookup.
          */
         var httpModule = options.get("httpModule");
+        
+        if (httpModule === "http2" && 
+            parseInt(process.versions.node.split(".")[0]) >= 9) {
+            return require("http2");
+        }
 
         if (typeof httpModule === "string") {
             /**


### PR DESCRIPTION
node-http2 is officially deprecated. The author recommends [using the native http2 module that ships with Node 9](https://github.com/molnarg/node-http2/commit/4f174b2e57127811aecf4898208611d186bd1279). 

Despite the `ExperimentalWarning: The http2 module is an experimental API` warning in the native module, it seems more stable than node-http2. I constantly ran into [an unhandled error](https://github.com/molnarg/node-http2/issues/147), which crashes Browsersync.