### PR TITLE
Fix "t is null" or "url is null" error when css is injected

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,73 @@
+<p align="center">
+<a href="https://ci.appveyor.com/project/shakyShane/browser-sync" title="AppVeyor branch">
+ <img src="https://img.shields.io/appveyor/ci/shakyshane/browser-sync/master.svg?style=flat-square&label=windows" />
+</a><a href="https://travis-ci.org/BrowserSync/browser-sync" title="Travis branch">
+ <img src="https://img.shields.io/travis/BrowserSync/browser-sync/master.svg?style=flat-square&label=linux" />
+</a><a href="https://www.npmjs.com/package/browser-sync">
+ <img src="https://img.shields.io/npm/dm/browser-sync.svg?style=flat-square" />
+</a>
+</p>
+<p align="center">
+<a href="https://www.npmjs.com/package/browser-sync" title="NPM version">
+ <img src="https://img.shields.io/npm/v/browser-sync.svg?style=flat-square" />
+</a><a href="https://david-dm.org/Browsersync/browser-sync" title="Dependency Status">
+ <img src="https://img.shields.io/david/Browsersync/browser-sync.svg?style=flat-square&label=deps" />
+</a>
+<a href="https://david-dm.org/Browsersync/browser-sync#info=devDependencies" title="devDependency Status">
+ <img src="https://img.shields.io/david/dev/Browsersync/browser-sync.svg?style=flat-square&label=devDeps" />
+</a>
+</p>
+<p align="center"><a href="https://www.browsersync.io"><img src="https://raw.githubusercontent.com/BrowserSync/browsersync.github.io/master/public/img/logo-gh.png" /></a></p>
+<p align="center">Keep multiple browsers & devices in sync when building websites.</p>
+
+<p align="center">Browsersync is developed and maintained internally at <a href="http://www.wearejh.com">JH</a></p>
+<p align="center">Follow <a href="https://twitter.com/browsersync">@Browsersync</a> on twitter for news & updates.</p>
+<p align="center">Community <a href="https://browsersync.herokuapp.com"><img src="https://browsersync.herokuapp.com/badge.svg" /></a></p>
+
 ## Features
 
-This repo is a fork of [browsersync.io](https://browsersync.io)
-This fork fixes some reload problems when inject css
+Please visit [browsersync.io](https://browsersync.io) for a full run-down of features
+
+## Requirements
+
+Browsersync works by injecting an asynchronous script tag (`<script async>...</script>`) right after the `<body>` tag
+during initial request. In order for this to work properly the `<body>` tag must be present. Alternatively you
+can provide a custom rule for the snippet using [snippetOptions](https://www.browsersync.io/docs/options/#option-snippetOptions)
+
+## Upgrading from 1.x to 2.x ?
+Providing you haven't accessed any internal properties, everything will just work as
+ there are no breaking changes to the public API. Internally however, we now use an
+ immutable data structure for storing/retrieving options. So whereas before you could access urls like this...
+
+```js
+browserSync({server: true}, function(err, bs) {
+    console.log(bs.options.urls.local);
+});
+```
+
+... you now access them in the following way:
+
+```js
+browserSync({server: true}, function(err, bs) {
+    console.log(bs.options.getIn(["urls", "local"]));
+});
+```
+
+## Install and trouble shooting
+
+[browsersync.io docs](https://browsersync.io)
+
+## Integrations / recipes
+
+[Browsersync recipes](https://github.com/Browsersync/recipes)
+
+## Support
+
+If you've found Browser-sync useful and would like to contribute to its continued development & support, please feel free to send a donation of any size - it would be greatly appreciated!
+
+[![Support via Gittip](https://rawgithub.com/chris---/Donation-Badges/master/gittip.jpeg)](https://www.gittip.com/shakyshane)
+[![Support via PayPal](https://rawgithub.com/chris---/Donation-Badges/master/paypal.jpeg)](https://www.paypal.com/cgi-bin/webscr?cmd=_donations&business=shakyshane%40gmail%2ecom&lc=US&item_name=browser%2dsync)
 
 
 Apache 2
-Copyright (c) 2018 Damián Vazquez
+Copyright (c) 2016 Shane Osbourne

--- a/README.md
+++ b/README.md
@@ -1,73 +1,8 @@
-<p align="center">
-<a href="https://ci.appveyor.com/project/shakyShane/browser-sync" title="AppVeyor branch">
- <img src="https://img.shields.io/appveyor/ci/shakyshane/browser-sync/master.svg?style=flat-square&label=windows" />
-</a><a href="https://travis-ci.org/BrowserSync/browser-sync" title="Travis branch">
- <img src="https://img.shields.io/travis/BrowserSync/browser-sync/master.svg?style=flat-square&label=linux" />
-</a><a href="https://www.npmjs.com/package/browser-sync">
- <img src="https://img.shields.io/npm/dm/browser-sync.svg?style=flat-square" />
-</a>
-</p>
-<p align="center">
-<a href="https://www.npmjs.com/package/browser-sync" title="NPM version">
- <img src="https://img.shields.io/npm/v/browser-sync.svg?style=flat-square" />
-</a><a href="https://david-dm.org/Browsersync/browser-sync" title="Dependency Status">
- <img src="https://img.shields.io/david/Browsersync/browser-sync.svg?style=flat-square&label=deps" />
-</a>
-<a href="https://david-dm.org/Browsersync/browser-sync#info=devDependencies" title="devDependency Status">
- <img src="https://img.shields.io/david/dev/Browsersync/browser-sync.svg?style=flat-square&label=devDeps" />
-</a>
-</p>
-<p align="center"><a href="https://www.browsersync.io"><img src="https://raw.githubusercontent.com/BrowserSync/browsersync.github.io/master/public/img/logo-gh.png" /></a></p>
-<p align="center">Keep multiple browsers & devices in sync when building websites.</p>
-
-<p align="center">Browsersync is developed and maintained internally at <a href="http://www.wearejh.com">JH</a></p>
-<p align="center">Follow <a href="https://twitter.com/browsersync">@Browsersync</a> on twitter for news & updates.</p>
-<p align="center">Community <a href="https://browsersync.herokuapp.com"><img src="https://browsersync.herokuapp.com/badge.svg" /></a></p>
-
 ## Features
 
-Please visit [browsersync.io](https://browsersync.io) for a full run-down of features
-
-## Requirements
-
-Browsersync works by injecting an asynchronous script tag (`<script async>...</script>`) right after the `<body>` tag
-during initial request. In order for this to work properly the `<body>` tag must be present. Alternatively you
-can provide a custom rule for the snippet using [snippetOptions](https://www.browsersync.io/docs/options/#option-snippetOptions)
-
-## Upgrading from 1.x to 2.x ?
-Providing you haven't accessed any internal properties, everything will just work as
- there are no breaking changes to the public API. Internally however, we now use an
- immutable data structure for storing/retrieving options. So whereas before you could access urls like this...
-
-```js
-browserSync({server: true}, function(err, bs) {
-    console.log(bs.options.urls.local);
-});
-```
-
-... you now access them in the following way:
-
-```js
-browserSync({server: true}, function(err, bs) {
-    console.log(bs.options.getIn(["urls", "local"]));
-});
-```
-
-## Install and trouble shooting
-
-[browsersync.io docs](https://browsersync.io)
-
-## Integrations / recipes
-
-[Browsersync recipes](https://github.com/Browsersync/recipes)
-
-## Support
-
-If you've found Browser-sync useful and would like to contribute to its continued development & support, please feel free to send a donation of any size - it would be greatly appreciated!
-
-[![Support via Gittip](https://rawgithub.com/chris---/Donation-Badges/master/gittip.jpeg)](https://www.gittip.com/shakyshane)
-[![Support via PayPal](https://rawgithub.com/chris---/Donation-Badges/master/paypal.jpeg)](https://www.paypal.com/cgi-bin/webscr?cmd=_donations&business=shakyshane%40gmail%2ecom&lc=US&item_name=browser%2dsync)
+This repo is a fork of [browsersync.io](https://browsersync.io)
+This fork fixes some reload problems when inject css
 
 
 Apache 2
-Copyright (c) 2016 Shane Osbourne
+Copyright (c) 2018 Damián Vazquez

--- a/client/dist/index.js
+++ b/client/dist/index.js
@@ -8193,7 +8193,7 @@ var Reloader = /** @class */ (function () {
             }
         });
         if (options.liveCSS) {
-            if (path.match(/\.css$/i)) {
+            if (path.match(/\.css$/i) && document.querySelector('link[href="'+path+'"]')) {
                 this.logger.trace("path.match(/\\.css$/i)", true);
                 if (this.reloadStylesheet(path)) {
                     return;
@@ -8365,7 +8365,7 @@ var Reloader = /** @class */ (function () {
         var links = ((function () {
             var result = [];
             [].slice.call(_this.document.getElementsByTagName('link')).forEach(function (link) {
-                if (link.rel.match(/^stylesheet$/i) && !link.__LiveReload_pendingRemoval) {
+                if (link.href !== '' && link.rel.match(/^stylesheet$/i) && !link.__LiveReload_pendingRemoval) {
                     result.push(link);
                 }
             });
@@ -8402,8 +8402,8 @@ var Reloader = /** @class */ (function () {
             }
         }
         else {
-            this.logger.info("reloading all stylesheets because path '" + path + "' did not match any specific one");
-            links.forEach(function (link) { return _this.reattachStylesheetLink(link); });
+            // this.logger.info("reloading all stylesheets because path '" + path + "' did not match any specific one");
+            // links.forEach(function (link) { return _this.reattachStylesheetLink(link); });
         }
         return true;
     };

--- a/client/vendor/Reloader.ts
+++ b/client/vendor/Reloader.ts
@@ -69,7 +69,7 @@ export class Reloader {
         })
 
         if (options.liveCSS) {
-            if (path.match(/\.css$/i)) {
+            if (path.match(/\.css$/i) && document.querySelector('link[href="'+path+'"]')) {
                 this.logger.trace(`path.match(/\\.css$/i)`, true);
                 if (this.reloadStylesheet(path)) {
                     return;
@@ -256,7 +256,7 @@ export class Reloader {
         const links = ((() => {
             const result = [];
             [].slice.call(this.document.getElementsByTagName('link')).forEach(link => {
-                if (link.rel.match(/^stylesheet$/i) && !link.__LiveReload_pendingRemoval) {
+                if (link.href !== '' &&  link.rel.match(/^stylesheet$/i) && !link.__LiveReload_pendingRemoval) {
                     result.push(link);
                 }
             });
@@ -294,8 +294,8 @@ export class Reloader {
                 this.reattachStylesheetLink(match.object);
             }
         } else {
-            this.logger.info(`reloading all stylesheets because path '${path}' did not match any specific one`);
-            links.forEach(link => this.reattachStylesheetLink(link));
+            // this.logger.info(`reloading all stylesheets because path '${path}' did not match any specific one`);
+            // links.forEach(link => this.reattachStylesheetLink(link));
         }
         return true;
     }


### PR DESCRIPTION
In major browsers an error will may occurs when css is injected.

This error appears in **Reloader vendor**, especially when use some workflow tool (like Gulp)

Full css reload when css not exists are commented. Should be an option in this library.