### PR TITLE
Update broken external link

### DIFF
--- a/cypress/integration.backup/example_spec.js
+++ b/cypress/integration.backup/example_spec.js
@@ -750,7 +750,7 @@ describe('Kitchen Sink', function () {
 
       // we can use Cypress.platform string to
       // select appropriate command
-      // https://on.cypress/io/platform
+      // https://on.cypress.io/platform
       cy.log(`Platform ${Cypress.platform} architecture ${Cypress.arch}`)
 
       if (Cypress.platform === 'win32') {


### PR DESCRIPTION
Updated a broken link reference that was a typo from:

https://on.cypress/io/platform

to

https://on.cypress.io/platform