### PR TITLE
deps: npm audit for localtunnel - fixes #1587

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -544,12 +544,6 @@
         "string-width": "^1.0.1"
       }
     },
-    "cli-width": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
-      "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
-      "dev": true
-    },
     "cliui": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
@@ -742,236 +736,6 @@
           "version": "5.5.1",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.1.tgz",
           "integrity": "sha512-PqpAxfrEhlSUWge8dwIp4tZnQ25DIOthpiaHNIthsjEFQD6EvqUKUDM7L8O2rShkFccYo1VjJR0coWfNkCubRw==",
-          "dev": true
-        }
-      }
-    },
-    "crossbow": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/crossbow/-/crossbow-4.3.0.tgz",
-      "integrity": "sha512-mo2ThuZWxW4VQMaBxQXv8U+R+uO/QtvGHql07ybm/a+RVTp4D/AAtjhRpxwtoQWcm8ai4dL49ih4qwhJcwkjRw==",
-      "dev": true,
-      "requires": {
-        "archy": "1.0.0",
-        "chokidar": "1.4.3",
-        "debug": "2.2.0",
-        "eazy-logger": "^3.0.2",
-        "hash-dir": "0.0.0",
-        "immutable": "3.8.0",
-        "inquirer": "1.0.1",
-        "js-yaml": "3.6.0",
-        "match-sorter": "^1.6.0",
-        "mkdirp": "^0.5.1",
-        "once": "1.3.3",
-        "qs": "6.1.0",
-        "rx": "4.1.0",
-        "rx-node": "1.0.2",
-        "tfunk": "^3.1.0",
-        "traverse": "0.6.6"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "ansi-styles": {
-          "version": "2.2.1",
-          "bundled": true,
-          "dev": true
-        },
-        "archy": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "argparse": {
-          "version": "1.0.9",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "sprintf-js": "~1.0.2"
-          }
-        },
-        "chalk": {
-          "version": "1.1.3",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^2.2.1",
-            "escape-string-regexp": "^1.0.2",
-            "has-ansi": "^2.0.0",
-            "strip-ansi": "^3.0.0",
-            "supports-color": "^2.0.0"
-          },
-          "dependencies": {
-            "escape-string-regexp": {
-              "version": "1.0.5",
-              "bundled": true,
-              "dev": true
-            },
-            "supports-color": {
-              "version": "2.0.0",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
-        "chokidar": {
-          "version": "1.4.3",
-          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.4.3.tgz",
-          "integrity": "sha1-X+czpNmsrqUbJkVLfllVkWPQ27I=",
-          "dev": true,
-          "requires": {
-            "anymatch": "^1.3.0",
-            "async-each": "^1.0.0",
-            "fsevents": "^1.0.0",
-            "glob-parent": "^2.0.0",
-            "inherits": "^2.0.1",
-            "is-binary-path": "^1.0.0",
-            "is-glob": "^2.0.0",
-            "path-is-absolute": "^1.0.0",
-            "readdirp": "^2.0.0"
-          }
-        },
-        "debug": {
-          "version": "2.2.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "ms": "0.7.1"
-          }
-        },
-        "esprima": {
-          "version": "2.7.3",
-          "bundled": true,
-          "dev": true
-        },
-        "has-ansi": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^2.0.0"
-          }
-        },
-        "hash-dir": {
-          "version": "0.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "once": "~1.2.0"
-          },
-          "dependencies": {
-            "once": {
-              "version": "1.2.0",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
-        "immutable": {
-          "version": "3.8.0",
-          "bundled": true,
-          "dev": true
-        },
-        "js-yaml": {
-          "version": "3.6.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "argparse": "^1.0.7",
-            "esprima": "^2.6.0"
-          }
-        },
-        "match-sorter": {
-          "version": "1.6.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "diacritic": "0.0.2",
-            "global-object": "1.0.0"
-          },
-          "dependencies": {
-            "diacritic": {
-              "version": "0.0.2",
-              "bundled": true,
-              "dev": true
-            },
-            "global-object": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
-        "ms": {
-          "version": "0.7.1",
-          "bundled": true,
-          "dev": true
-        },
-        "object-path": {
-          "version": "0.9.2",
-          "bundled": true,
-          "dev": true
-        },
-        "once": {
-          "version": "1.3.3",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "wrappy": "1"
-          }
-        },
-        "qs": {
-          "version": "6.1.0",
-          "bundled": true,
-          "dev": true
-        },
-        "rx": {
-          "version": "4.1.0",
-          "bundled": true,
-          "dev": true
-        },
-        "rx-node": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "rx": "*"
-          }
-        },
-        "sprintf-js": {
-          "version": "1.0.3",
-          "bundled": true,
-          "dev": true
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^2.0.0"
-          }
-        },
-        "tfunk": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/tfunk/-/tfunk-3.1.0.tgz",
-          "integrity": "sha1-OORBT8ZJd9h6/apy+sttKfgve1s=",
-          "dev": true,
-          "requires": {
-            "chalk": "^1.1.1",
-            "object-path": "^0.9.0"
-          }
-        },
-        "traverse": {
-          "version": "0.6.6",
-          "bundled": true,
-          "dev": true
-        },
-        "wrappy": {
-          "version": "1.0.2",
-          "bundled": true,
           "dev": true
         }
       }
@@ -1634,9 +1398,9 @@
       }
     },
     "follow-redirects": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.0.tgz",
-      "integrity": "sha512-fdrt472/9qQ6Kgjvb935ig6vJCuofpBUD14f9Vb+SLlm7xIe4Qva5gey8EKtv8lp7ahE1wilg3xL1znpVGtZIA==",
+      "version": "1.5.7",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.7.tgz",
+      "integrity": "sha512-NONJVIFiX7Z8k2WxfqBjtwqMifx7X42ORLFrOZ2LTKGj71G3C0kfdyTqGqr8fx5zSX6Foo/D95dgGWbPUiwnew==",
       "requires": {
         "debug": "^3.1.0"
       },
@@ -2473,35 +2237,6 @@
       "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
       "dev": true
     },
-    "inquirer": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-1.0.1.tgz",
-      "integrity": "sha1-bUo0QmCJMf/xSgwLhgxQBEZcTgc=",
-      "dev": true,
-      "requires": {
-        "ansi-escapes": "^1.1.0",
-        "chalk": "^1.0.0",
-        "cli-cursor": "^1.0.1",
-        "cli-width": "^2.0.0",
-        "figures": "^1.3.5",
-        "lodash": "^4.3.0",
-        "mute-stream": "0.0.6",
-        "pinkie-promise": "^2.0.0",
-        "run-async": "^2.2.0",
-        "rx": "^4.1.0",
-        "string-width": "^1.0.1",
-        "strip-ansi": "^3.0.0",
-        "through": "^2.3.6"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "4.17.10",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
-          "dev": true
-        }
-      }
-    },
     "invert-kv": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
@@ -2890,27 +2625,19 @@
       }
     },
     "localtunnel": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/localtunnel/-/localtunnel-1.9.0.tgz",
-      "integrity": "sha512-wCIiIHJ8kKIcWkTQE3m1VRABvsH2ZuOkiOpZUofUCf6Q42v3VIZ+Q0YfX1Z4sYDRj0muiKL1bLvz1FeoxsPO0w==",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/localtunnel/-/localtunnel-1.9.1.tgz",
+      "integrity": "sha512-HWrhOslklDvxgOGFLxi6fQVnvpl6XdX4sPscfqMZkzi3gtt9V7LKBWYvNUcpHSVvjwCQ6xzXacVvICNbNcyPnQ==",
       "requires": {
         "axios": "0.17.1",
-        "debug": "2.6.8",
+        "debug": "2.6.9",
         "openurl": "1.1.1",
         "yargs": "6.6.0"
       },
       "dependencies": {
-        "debug": {
-          "version": "2.6.8",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-          "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
         "yargs": {
           "version": "6.6.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-6.6.0.tgz",
+          "resolved": "http://registry.npmjs.org/yargs/-/yargs-6.6.0.tgz",
           "integrity": "sha1-eC7CHvQDNF+DCoCMo9UTr1YGUgg=",
           "requires": {
             "camelcase": "^3.0.0",
@@ -3481,12 +3208,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-    },
-    "mute-stream": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.6.tgz",
-      "integrity": "sha1-SJYrGeFp/R38JAs/HnMXYnu8R9s=",
-      "dev": true
     },
     "nan": {
       "version": "2.10.0",
@@ -4153,15 +3874,6 @@
         "glob": "^7.0.5"
       }
     },
-    "run-async": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
-      "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
-      "dev": true,
-      "requires": {
-        "is-promise": "^2.1.0"
-      }
-    },
     "rx": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/rx/-/rx-4.1.0.tgz",
@@ -4662,12 +4374,6 @@
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-0.0.2.tgz",
       "integrity": "sha1-z+34jmDADdlpe2H90qg0OptoDq8=",
-      "dev": true
-    },
-    "through": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
     },
     "tmp": {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "fs-extra": "3.0.1",
     "http-proxy": "1.15.2",
     "immutable": "3.8.2",
-    "localtunnel": "1.9.0",
+    "localtunnel": "1.9.1",
     "micromatch": "2.3.11",
     "opn": "5.3.0",
     "portscanner": "2.1.1",


### PR DESCRIPTION
`npm audit` describes three vulnerabilities in package.json. [localtunnel](https://github.com/localtunnel/localtunnel/pull/256) was recently updated to remove its low-level vulnerability in the debug module. After the update, they made a new release to v1.9.1.

This PR bumps the version for `localtunnel` in BrowserSync to 1.9.1, removing the security vulnerability within the browser-sync npm module.