### PR TITLE
proxy: case insensitive matching of cookie domain

### DIFF
--- a/lib/server/proxy-utils.js
+++ b/lib/server/proxy-utils.js
@@ -133,7 +133,7 @@ function rewriteCookies(rawCookie) {
 
     var pairs = Object.keys(objCookie)
         .filter(function(item) {
-            return item !== "domain";
+            return item.toLowerCase() !== "domain";
         })
         .map(function(key) {
             return key + "=" + objCookie[key];


### PR DESCRIPTION
The `Domain` directive should be matched ignoring case