### PR TITLE
Removing default logger prefix [BS]

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -7,7 +7,6 @@ var _ = require("./lodash.custom");
 var template = "[{blue:%s}] ";
 
 var logger = require("eazy-logger").Logger({
-    prefix: template.replace("%s", "BS"),
     useLevelPrefixes: false
 });
 


### PR DESCRIPTION
When specifying the `logPrefix` option to `null`, `undefined`, or an empty string the logger prints `[BS]`
![image](https://user-images.githubusercontent.com/8790386/45904126-bfa91800-bdf4-11e8-91c3-d0230cdcc163.png)

Useful when using [concurrently](https://www.npmjs.com/package/concurrently) to run BrowserSync alongside other processes. Double prefix is kind of redundant.
![image](https://user-images.githubusercontent.com/8790386/45904395-963cbc00-bdf5-11e8-824a-6266228b5e05.png)