### PR TITLE
Expose IP address and disconnect event

### DIFF
--- a/packages/browser-sync/lib/sockets.js
+++ b/packages/browser-sync/lib/sockets.js
@@ -60,7 +60,15 @@ module.exports.init = function(server, clientEvents, bs) {
         client.emit("connection", bs.options.toJS()); //todo - trim the amount of options sent to clients
 
         emitter.emit("client:connected", {
-            ua: client.handshake.headers["user-agent"]
+            ua: client.handshake.headers["user-agent"],
+            ip: client.handshake.address
+        });
+        
+        client.on("disconnect", function() {
+            emitter.emit("client:disconnected", {
+                ua: client.handshake.headers["user-agent"],
+                ip: client.handshake.address
+            });
         });
     }
 


### PR DESCRIPTION
### Summary
I'd like to be notified of when someone has connected to my session _externally_.

Since `logConnections: true` only emits a single `Browser Connected: . . .` line, I am using the following event to be notified of new connections:
```javascript
const bsUtils = require('browser-sync/dist/utils');

const emitter = browserSync.emitter;
emitter.on("client:connected", function ( data ) {
	let uaString = bsUtils.getUaString(data.ua);
	
	console.log(chalk`{green Connected:}`,
		`${uaString.name} version ${uaString.version}, IP: ${data.ip}`);

	// Additionally make a toast notification, if ( data.ip is external )
	nodeNotifier.notify({
		title: 'Browser connected',
		message: `${uaString.name} version ${uaString.version}, IP: ${data.ip}`,
		sound: false
	});

});

emitter.on("client:disconnected", function ( data ) {
	let uaString = bsUtils.getUaString(data.ua);
	
	console.log(chalk`{red Disconnected:}`,
		`${uaString.name} version ${uaString.version}`, chalk`{yellow IP:}`, `${data.ip}`);
});
```

However, without exposing `handshake.address` and `client.on("disconnect", { . . . })` methods, it's impossible to be notified of such events.

### Scope
This PR exposes `socket.io`'s following properties in order to write custom event listeners:
- `handshake.address`
- `client.on("disconnect", { . . . })`

### Status
- tested on my machine, and it works

### Feedback
Happy to hear it from you :)