### PR TITLE
Fixed Socket Port option

### DIFF
--- a/packages/browser-sync/lib/connect-utils.js
+++ b/packages/browser-sync/lib/connect-utils.js
@@ -159,7 +159,7 @@ var connectUtils = {
             "'{protocol}' + location.hostname + ':{port}{ns}'";
         var withHost = "'{protocol}' + location.host + '{ns}'";
         var withDomain = "'{domain}{ns}'";
-        var port = options.get("port");
+        var port = socketOpts.port || options.get("port");
 
         // default use-case is server/proxy
         var string = withHost;


### PR DESCRIPTION
The socket port option documented in https://www.browsersync.io/docs/options/#option-socket did not affect anything. This allows the socket.port option to override the default port option so browser-sync can work in situations where the external port does not coincide with the internal port (ex: inside a docker container with fixed external port). With quick testing, this seems to allow the socket.port option to change the port the socket connects to from the client. 