### PR TITLE
Use `res.getHeaders()`

### DIFF
--- a/packages/browser-sync-client/index.js
+++ b/packages/browser-sync-client/index.js
@@ -92,7 +92,7 @@ function init(options, requestBody, type) {
          * Set the appropriate headers for caching
          */
         setHeaders(res, output);
-        if (isConditionalGet(req) && fresh(req.headers, res._headers)) {
+        if (isConditionalGet(req) && fresh(req.headers, res.getHeaders())) {
             return notModified(res);
         }
 


### PR DESCRIPTION
Fixes the deprecation warning thrown, **but requires Node.js >= 7.7.0**

I guess this can't land anytime soon because of the Node.js requirement. But maybe it gives someone else some motivation to fix it in another way.

Fixes #1688