### PR TITLE
Use getHeaders or _headers - fixes #1688

### DIFF
--- a/packages/browser-sync-client/index.js
+++ b/packages/browser-sync-client/index.js
@@ -92,7 +92,8 @@ function init(options, requestBody, type) {
          * Set the appropriate headers for caching
          */
         setHeaders(res, output);
-        if (isConditionalGet(req) && fresh(req.headers, res._headers)) {
+        var resHeaders = res.getHeaders ? res.getHeaders() : res._headers;
+        if (isConditionalGet(req) && fresh(req.headers, resHeaders)) {
             return notModified(res);
         }
 


### PR DESCRIPTION
https://github.com/BrowserSync/browser-sync/pull/1689

This PR failed AppVayor building for old node version(ver 4).
So, I created compatible old and new API calling patch.

Fixes #1688