### PR TITLE
Replace `document.write` with `appendChild` method

### DIFF
--- a/packages/browser-sync/templates/script-tags.tmpl
+++ b/packages/browser-sync/templates/script-tags.tmpl
@@ -1,3 +1,6 @@
 <script id="__bs_script__">//<![CDATA[
-    document.write("<script %async% src='%script%'><\/script>".replace("HOST", location.hostname));
+    let script = document.createElement('script');
+    script.setAttribute('async', '');
+    script.setAttribute('src', '%script%'.replace("HOST", location.hostname));
+    document.body.appendChild(script);
 //]]></script>


### PR DESCRIPTION
As per issue #1600 Chrome browsers throw a violation warning in the console when `document.write` is used for injecting elements.
Using the 'appendChild' method to inject the script tag mitigates the violation.

Violation reference:
https://developers.google.com/web/updates/2016/08/removing-document-write