### PR TITLE
fix(browser-sync): adapt yargs version method call

### DIFF
--- a/packages/browser-sync/lib/bin.ts
+++ b/packages/browser-sync/lib/bin.ts
@@ -43,7 +43,7 @@ function runFromCli() {
         .command("init", "Create a configuration file")
         .command("reload", "Send a reload event over HTTP protocol")
         .command("recipe", "Generate the files for a recipe")
-        .version(() => pkg.version)
+        .version(pkg.version)
         .epilogue(
             [
                 "For help running a certain command, type <command> --help",


### PR DESCRIPTION
In last 8 days I saw that `yargs` was upgrade `6.4.0` to `^15.4.1`
And from the changelogs I saw that there are a lot of breaking changes.

- https://github.com/yargs/yargs/blob/master/docs/CHANGELOG-historical.md
- https://github.com/yargs/yargs/blob/master/CHANGELOG.md

I took a look and it seems only `yargs.version` was changed and is used in codebase.

Closes #1782