### PR TITLE
deps: portscanner - fixes incompatible arguments

### DIFF
--- a/packages/browser-sync/package.json
+++ b/packages/browser-sync/package.json
@@ -51,7 +51,7 @@
     "localtunnel": "^2.0.0",
     "micromatch": "^4.0.2",
     "opn": "5.3.0",
-    "portscanner": "2.1.1",
+    "portscanner": "2.2.0",
     "qs": "6.2.3",
     "raw-body": "^2.3.2",
     "resp-modifier": "6.0.2",


### PR DESCRIPTION
Solution for https://github.com/BrowserSync/browser-sync/pull/1431#issuecomment-436978098

Browser-sync [currently uses portscanner v2.1.1](https://github.com/BrowserSync/browser-sync/blob/0cbdfd147614bf3da52bf0b4559feadf470ae1a0/packages/browser-sync/package.json#L54), but [passes `host` via `options` to portscanner](https://github.com/BrowserSync/browser-sync/blob/0cbdfd147614bf3da52bf0b4559feadf470ae1a0/packages/browser-sync/lib/utils.ts#L145). This is supported [since portscanner v2.2.0](https://github.com/baalexander/node-portscanner/pull/56).

One solution is to fix browser-sync call to pass arguments correctly. Another solution is to upgrade portscanner to v2.2.0. This PR upgrades portscanner to v2.2.0.