### PR TITLE
Fix #1799 - pesticide link

### DIFF
--- a/cypress/integration/ui-remote-debug.js
+++ b/cypress/integration/ui-remote-debug.js
@@ -10,7 +10,7 @@ describe('UI', function () {
                         "active": true,
                         "hidden": "",
                         "name": "pesticide",
-                        "tagline": "Add simple CSS outlines to all elements. (powered by <a href=\"http://pesticide.io\" target=\"_blank\">Pesticide.io</a>)",
+                        "tagline": "Add simple CSS outlines to all elements. (powered by <span style='text-decoration: line-through'>Pesticide.io</span>)",
                         "context": "remote-debug",
                         "served": true,
                         "title": "CSS Outlining",

--- a/packages/browser-sync-ui/lib/plugins/remote-debug/client-files.js
+++ b/packages/browser-sync-ui/lib/plugins/remote-debug/client-files.js
@@ -9,7 +9,7 @@ var files = [
         served: false,
         name: "pesticide",
         src: "/browser-sync/pesticide.css",
-        tagline: "Add simple CSS outlines to all elements. (powered by <a href=\"http://pesticide.io\" target=\"_blank\">Pesticide.io</a>)",
+        tagline: "Add simple CSS outlines to all elements. (powered by <span style='text-decoration: line-through'>Pesticide.io</span>)",
         hidden: ""
     },
     {
@@ -22,7 +22,7 @@ var files = [
         served: false,
         name: "pesticide-depth",
         src: "/browser-sync/pesticide-depth.css",
-        tagline: "Add CSS box-shadows to all elements. (powered by <a href=\"http://pesticide.io\" target=\"_blank\">Pesticide.io</a>)",
+        tagline: "Add CSS box-shadows to all elements. (powered by <span style='text-decoration: line-through'>Pesticide.io</span>)",
         hidden: ""
     },
     {


### PR DESCRIPTION
Switch out malicious link for crossed-out in-line reference. Enough to track origin for historical purposes, but prevents mindless linking and malicious attack by taken-over website.