### PR TITLE
browser-sync setOption: allow value to be undefined

### DIFF
--- a/packages/browser-sync/lib/browser-sync.js
+++ b/packages/browser-sync/lib/browser-sync.js
@@ -509,7 +509,7 @@ BrowserSync.prototype.setOption = function(name, value, opts) {
 
     opts = opts || {};
 
-    bs.debug("Setting Option: {cyan:%s} - {magenta:%s", name, value.toString());
+    bs.debug("Setting Option: {cyan:%s} - {magenta:%s", name, value?.toString());
 
     bs.options = bs.options.set(name, value);
 


### PR DESCRIPTION
otherwise i get `TypeError: Cannot read property 'toString' of undefined`

sample with patch: when the port is undefined, eleventy will say

```
[11ty] [Browsersync] Access URLs:
[11ty]  -------------------------------------------
[11ty]        Local: http://localhost:undefined
[11ty]     External: http://192.168.1.120:undefined
```
