### PR TITLE
Fix `ua-parser-js` dependency version. (hijacked package)

### DIFF
--- a/packages/browser-sync/package.json
+++ b/packages/browser-sync/package.json
@@ -61,7 +61,7 @@
 		"serve-static": "1.13.2",
 		"server-destroy": "1.0.1",
 		"socket.io": "2.4.0",
-		"ua-parser-js": "^0.7.28",
+		"ua-parser-js": "0.7.28",
 		"yargs": "^15.4.1"
 	},
 	"devDependencies": {


### PR DESCRIPTION
Fix `ua-parser-js` dependency version. (hijacked package)

As per the warning [on the npm page](https://www.npmjs.com/package/ua-parser-js):

> This package has been hijacked. Please revert to 0.7.28