### PR TITLE
Replace `document.write`with `appendChild` method

### DIFF
--- a/packages/browser-sync/templates/script-tags.tmpl
+++ b/packages/browser-sync/templates/script-tags.tmpl
@@ -1,5 +1,5 @@
 <script id="__bs_script__">//<![CDATA[
-    let script = document.createElement('script');
+    var script = document.createElement('script');
     script.setAttribute('async', '');
     script.setAttribute('src', '%script%'.replace("HOST", location.hostname));
     document.body.appendChild(script);

--- a/packages/browser-sync/templates/script-tags.tmpl
+++ b/packages/browser-sync/templates/script-tags.tmpl
@@ -1,3 +1,6 @@
 <script id="__bs_script__">//<![CDATA[
-    document.write("<script %async% src='%script%'><\/script>".replace("HOST", location.hostname));
+    let script = document.createElement('script');
+    script.setAttribute('async', '');
+    script.setAttribute('src', '%script%'.replace("HOST", location.hostname));
+    document.body.appendChild(script);
 //]]></script>


### PR DESCRIPTION
This is an updated PR for #1736 that replaces the usage of let with var.

I did this since the usage of let was criticized in a review on the original PR almost a year ago with no update since.