### PR TITLE
Forces "secure" to be re-added to parsed cookies

### DIFF
--- a/packages/browser-sync/lib/server/proxy-utils.js
+++ b/packages/browser-sync/lib/server/proxy-utils.js
@@ -151,6 +151,9 @@ function rewriteCookies(rawCookie) {
     if (rawCookie.match(/httponly/i)) {
         pairs.push("HttpOnly");
     }
+    if (rawCookie.match(/secure/i)) {
+      pairs.push('secure');
+    }
 
     return pairs.join("; ");
 }


### PR DESCRIPTION
At Half Helix, we've recently had an issue with submitting a critical HTTP-based password form on Shopify sites when the site is proxied with BrowserSync. This is relevant to sites that use: https://kit.halfhelix.com for development, which in turn uses BrowserSync behind the scenes.

The issue stems from cookies that have SameSite=Note (see link below). Since SameSite=None requires "secure" to be set but secure does not have a key value pair, the BrowserSync code is removing "secure" from the cookie definition and thus invalidating this type of cookie.

This is likely to have downstream effects so it might be too primitive to merge in immediately but it is an issue that needs to be addressed.

See: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite#samesitenone_requires_secure.

