### PR TITLE
fix: socket.io has an unhandled 'error' event

### DIFF
--- a/packages/browser-sync/package-lock.json
+++ b/packages/browser-sync/package-lock.json
@@ -34,7 +34,7 @@
 				"serve-index": "1.9.1",
 				"serve-static": "1.13.2",
 				"server-destroy": "1.0.1",
-				"socket.io": "^4.4.1",
+				"socket.io": "^4.7.5",
 				"ua-parser-js": "^1.0.33",
 				"yargs": "^17.3.1"
 			},
@@ -77,9 +77,9 @@
 			"integrity": "sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q=="
 		},
 		"node_modules/@types/cors": {
-			"version": "2.8.13",
-			"resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.13.tgz",
-			"integrity": "sha512-RG8AStHlUiV5ysZQKq97copd2UmVYw3/pRMLefISZ3S1hK104Cwm7iLQ3fTKx+lsUH2CE8FlLaYeEA2LSeqYUA==",
+			"version": "2.8.17",
+			"resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.17.tgz",
+			"integrity": "sha512-8CGDvrBj1zgo2qE+oS3pOCyYNqCPryMWY2bGfwA0dcfopWGgxs+78df0Rs3rc9THP4JkOhLsAa+15VdpAqkcUA==",
 			"dependencies": {
 				"@types/node": "*"
 			}
@@ -332,9 +332,9 @@
 			"dev": true
 		},
 		"node_modules/browser-sync-client": {
-			"version": "3.0.0-alpha.1",
-			"resolved": "https://registry.npmjs.org/browser-sync-client/-/browser-sync-client-3.0.0-alpha.1.tgz",
-			"integrity": "sha512-k6dLFlbnvEK79gmbTHdPe2Ei9KULWwpehcF3Q9AKP2einkofly8ZglZBMgz8GjEMdeOIVOzEd3Q5lIZVh+Cu0w==",
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/browser-sync-client/-/browser-sync-client-3.0.2.tgz",
+			"integrity": "sha512-tBWdfn9L0wd2Pjuz/NWHtNEKthVb1Y67vg8/qyGNtCqetNz5lkDkFnrsx5UhPNPYUO8vci50IWC/BhYaQskDiQ==",
 			"dependencies": {
 				"etag": "1.8.1",
 				"fresh": "0.5.2",
@@ -345,9 +345,9 @@
 			}
 		},
 		"node_modules/browser-sync-ui": {
-			"version": "3.0.0-alpha.1",
-			"resolved": "https://registry.npmjs.org/browser-sync-ui/-/browser-sync-ui-3.0.0-alpha.1.tgz",
-			"integrity": "sha512-AmGlpOYaMLRJ28cELXlzvGrbt1tPNChYxfd+dP57eIsj8kP9QbeFqSc9raRDHDA5Hq6W2hHpCZT5CL5hWkVeQA==",
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/browser-sync-ui/-/browser-sync-ui-3.0.2.tgz",
+			"integrity": "sha512-V3FwWAI+abVbFLTyJjXJlCMBwjc3GXf/BPGfwO2fMFACWbIGW9/4SrBOFYEOOtqzCjQE0Di+U3VIb7eES4omNA==",
 			"dependencies": {
 				"async-each-series": "0.1.1",
 				"chalk": "4.1.2",
@@ -359,9 +359,9 @@
 			}
 		},
 		"node_modules/browser-sync-ui/node_modules/debug": {
-			"version": "4.3.4",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-			"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+			"version": "4.3.5",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.5.tgz",
+			"integrity": "sha512-pt0bNEmneDIvdL1Xsd9oDQ/wrQRkXDT4AUWlNZNPKvW5x/jyO9VFXkJUP07vQ2upmw5PlaITaPKc31jK13V+jg==",
 			"dependencies": {
 				"ms": "2.1.2"
 			},
@@ -375,21 +375,21 @@
 			}
 		},
 		"node_modules/browser-sync-ui/node_modules/engine.io-client": {
-			"version": "6.4.0",
-			"resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.4.0.tgz",
-			"integrity": "sha512-GyKPDyoEha+XZ7iEqam49vz6auPnNJ9ZBfy89f+rMMas8AuiMWOZ9PVzu8xb9ZC6rafUqiGHSCfu22ih66E+1g==",
+			"version": "6.5.4",
+			"resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.5.4.tgz",
+			"integrity": "sha512-GeZeeRjpD2qf49cZQ0Wvh/8NJNfeXkXXcoGh+F77oEAgo9gUHwT1fCRxSNU+YEEaysOJTnsFHmM5oAcPy4ntvQ==",
 			"dependencies": {
 				"@socket.io/component-emitter": "~3.1.0",
 				"debug": "~4.3.1",
-				"engine.io-parser": "~5.0.3",
-				"ws": "~8.11.0",
+				"engine.io-parser": "~5.2.1",
+				"ws": "~8.17.1",
 				"xmlhttprequest-ssl": "~2.0.0"
 			}
 		},
 		"node_modules/browser-sync-ui/node_modules/engine.io-parser": {
-			"version": "5.0.6",
-			"resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.0.6.tgz",
-			"integrity": "sha512-tjuoZDMAdEhVnSFleYPCtdL2GXwVTGtNjoeJd9IhIG3C1xs9uwxqRNEu5WpnDZCaozwVlK/nuQhpodhXSIMaxw==",
+			"version": "5.2.2",
+			"resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.2.tgz",
+			"integrity": "sha512-RcyUFKA93/CXH20l4SoVvzZfrSDMOTUS3bWVpTt2FuFP+XYrL8i8oonHP7WInRyVHXh0n/ORtoeiE1os+8qkSw==",
 			"engines": {
 				"node": ">=10.0.0"
 			}
@@ -400,29 +400,29 @@
 			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
 		},
 		"node_modules/browser-sync-ui/node_modules/socket.io-client": {
-			"version": "4.6.1",
-			"resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.6.1.tgz",
-			"integrity": "sha512-5UswCV6hpaRsNg5kkEHVcbBIXEYoVbMQaHJBXJCyEQ+CiFPV1NIOY0XOFWG4XR4GZcB8Kn6AsRs/9cy9TbqVMQ==",
+			"version": "4.7.5",
+			"resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.7.5.tgz",
+			"integrity": "sha512-sJ/tqHOCe7Z50JCBCXrsY3I2k03iOiUe+tj1OmKeD2lXPiGH/RUCdTZFoqVyN7l1MnpIzPrGtLcijffmeouNlQ==",
 			"dependencies": {
 				"@socket.io/component-emitter": "~3.1.0",
 				"debug": "~4.3.2",
-				"engine.io-client": "~6.4.0",
-				"socket.io-parser": "~4.2.1"
+				"engine.io-client": "~6.5.2",
+				"socket.io-parser": "~4.2.4"
 			},
 			"engines": {
 				"node": ">=10.0.0"
 			}
 		},
 		"node_modules/browser-sync-ui/node_modules/ws": {
-			"version": "8.11.0",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
-			"integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
+			"version": "8.17.1",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
+			"integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
 			"engines": {
 				"node": ">=10.0.0"
 			},
 			"peerDependencies": {
 				"bufferutil": "^4.0.1",
-				"utf-8-validate": "^5.0.2"
+				"utf-8-validate": ">=5.0.2"
 			},
 			"peerDependenciesMeta": {
 				"bufferutil": {
@@ -831,9 +831,9 @@
 			}
 		},
 		"node_modules/engine.io": {
-			"version": "6.4.2",
-			"resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.4.2.tgz",
-			"integrity": "sha512-FKn/3oMiJjrOEOeUub2WCox6JhxBXq/Zn3fZOMCBxKnNYtsdKjxhl7yR3fZhM9PV+rdE75SU5SYMc+2PGzo+Tg==",
+			"version": "6.5.5",
+			"resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.5.5.tgz",
+			"integrity": "sha512-C5Pn8Wk+1vKBoHghJODM63yk8MvrO9EWZUfkAt5HAqIgPE4/8FF0PEGHXtEd40l223+cE5ABWuPzm38PHFXfMA==",
 			"dependencies": {
 				"@types/cookie": "^0.4.1",
 				"@types/cors": "^2.8.12",
@@ -843,11 +843,11 @@
 				"cookie": "~0.4.1",
 				"cors": "~2.8.5",
 				"debug": "~4.3.1",
-				"engine.io-parser": "~5.0.3",
-				"ws": "~8.11.0"
+				"engine.io-parser": "~5.2.1",
+				"ws": "~8.17.1"
 			},
 			"engines": {
-				"node": ">=10.0.0"
+				"node": ">=10.2.0"
 			}
 		},
 		"node_modules/engine.io-client": {
@@ -892,14 +892,17 @@
 			}
 		},
 		"node_modules/engine.io/node_modules/@types/node": {
-			"version": "18.16.3",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.16.3.tgz",
-			"integrity": "sha512-OPs5WnnT1xkCBiuQrZA4+YAV4HEJejmHneyraIaxsbev5yCEr6KMwINNFP9wQeFIw8FWcoTqF3vQsa5CDaI+8Q=="
+			"version": "20.14.6",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.6.tgz",
+			"integrity": "sha512-JbA0XIJPL1IiNnU7PFxDXyfAwcwVVrOoqyzzyQTyMeVhBzkJVMSkC1LlVsRQ2lpqiY4n6Bb9oCS6lzDKVQxbZw==",
+			"dependencies": {
+				"undici-types": "~5.26.4"
+			}
 		},
 		"node_modules/engine.io/node_modules/debug": {
-			"version": "4.3.4",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-			"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+			"version": "4.3.5",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.5.tgz",
+			"integrity": "sha512-pt0bNEmneDIvdL1Xsd9oDQ/wrQRkXDT4AUWlNZNPKvW5x/jyO9VFXkJUP07vQ2upmw5PlaITaPKc31jK13V+jg==",
 			"dependencies": {
 				"ms": "2.1.2"
 			},
@@ -913,9 +916,9 @@
 			}
 		},
 		"node_modules/engine.io/node_modules/engine.io-parser": {
-			"version": "5.0.6",
-			"resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.0.6.tgz",
-			"integrity": "sha512-tjuoZDMAdEhVnSFleYPCtdL2GXwVTGtNjoeJd9IhIG3C1xs9uwxqRNEu5WpnDZCaozwVlK/nuQhpodhXSIMaxw==",
+			"version": "5.2.2",
+			"resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.2.tgz",
+			"integrity": "sha512-RcyUFKA93/CXH20l4SoVvzZfrSDMOTUS3bWVpTt2FuFP+XYrL8i8oonHP7WInRyVHXh0n/ORtoeiE1os+8qkSw==",
 			"engines": {
 				"node": ">=10.0.0"
 			}
@@ -926,15 +929,15 @@
 			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
 		},
 		"node_modules/engine.io/node_modules/ws": {
-			"version": "8.11.0",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
-			"integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
+			"version": "8.17.1",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
+			"integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
 			"engines": {
 				"node": ">=10.0.0"
 			},
 			"peerDependencies": {
 				"bufferutil": "^4.0.1",
-				"utf-8-validate": "^5.0.2"
+				"utf-8-validate": ">=5.0.2"
 			},
 			"peerDependenciesMeta": {
 				"bufferutil": {
@@ -2461,19 +2464,20 @@
 			}
 		},
 		"node_modules/socket.io": {
-			"version": "4.6.1",
-			"resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.6.1.tgz",
-			"integrity": "sha512-KMcaAi4l/8+xEjkRICl6ak8ySoxsYG+gG6/XfRCPJPQ/haCRIJBTL4wIl8YCsmtaBovcAXGLOShyVWQ/FG8GZA==",
+			"version": "4.7.5",
+			"resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.7.5.tgz",
+			"integrity": "sha512-DmeAkF6cwM9jSfmp6Dr/5/mfMwb5Z5qRrSXLpo3Fq5SqyU8CMF15jIN4ZhfSwu35ksM1qmHZDQ/DK5XTccSTvA==",
 			"dependencies": {
 				"accepts": "~1.3.4",
 				"base64id": "~2.0.0",
+				"cors": "~2.8.5",
 				"debug": "~4.3.2",
-				"engine.io": "~6.4.1",
+				"engine.io": "~6.5.2",
 				"socket.io-adapter": "~2.5.2",
-				"socket.io-parser": "~4.2.1"
+				"socket.io-parser": "~4.2.4"
 			},
 			"engines": {
-				"node": ">=10.0.0"
+				"node": ">=10.2.0"
 			}
 		},
 		"node_modules/socket.io-adapter": {
@@ -2861,6 +2865,11 @@
 				"node": "*"
 			}
 		},
+		"node_modules/undici-types": {
+			"version": "5.26.5",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+			"integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
+		},
 		"node_modules/universalify": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
@@ -3155,9 +3164,9 @@
 			"integrity": "sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q=="
 		},
 		"@types/cors": {
-			"version": "2.8.13",
-			"resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.13.tgz",
-			"integrity": "sha512-RG8AStHlUiV5ysZQKq97copd2UmVYw3/pRMLefISZ3S1hK104Cwm7iLQ3fTKx+lsUH2CE8FlLaYeEA2LSeqYUA==",
+			"version": "2.8.17",
+			"resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.17.tgz",
+			"integrity": "sha512-8CGDvrBj1zgo2qE+oS3pOCyYNqCPryMWY2bGfwA0dcfopWGgxs+78df0Rs3rc9THP4JkOhLsAa+15VdpAqkcUA==",
 			"requires": {
 				"@types/node": "*"
 			}
@@ -3364,9 +3373,9 @@
 			"dev": true
 		},
 		"browser-sync-client": {
-			"version": "3.0.0-alpha.1",
-			"resolved": "https://registry.npmjs.org/browser-sync-client/-/browser-sync-client-3.0.0-alpha.1.tgz",
-			"integrity": "sha512-k6dLFlbnvEK79gmbTHdPe2Ei9KULWwpehcF3Q9AKP2einkofly8ZglZBMgz8GjEMdeOIVOzEd3Q5lIZVh+Cu0w==",
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/browser-sync-client/-/browser-sync-client-3.0.2.tgz",
+			"integrity": "sha512-tBWdfn9L0wd2Pjuz/NWHtNEKthVb1Y67vg8/qyGNtCqetNz5lkDkFnrsx5UhPNPYUO8vci50IWC/BhYaQskDiQ==",
 			"requires": {
 				"etag": "1.8.1",
 				"fresh": "0.5.2",
@@ -3374,9 +3383,9 @@
 			}
 		},
 		"browser-sync-ui": {
-			"version": "3.0.0-alpha.1",
-			"resolved": "https://registry.npmjs.org/browser-sync-ui/-/browser-sync-ui-3.0.0-alpha.1.tgz",
-			"integrity": "sha512-AmGlpOYaMLRJ28cELXlzvGrbt1tPNChYxfd+dP57eIsj8kP9QbeFqSc9raRDHDA5Hq6W2hHpCZT5CL5hWkVeQA==",
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/browser-sync-ui/-/browser-sync-ui-3.0.2.tgz",
+			"integrity": "sha512-V3FwWAI+abVbFLTyJjXJlCMBwjc3GXf/BPGfwO2fMFACWbIGW9/4SrBOFYEOOtqzCjQE0Di+U3VIb7eES4omNA==",
 			"requires": {
 				"async-each-series": "0.1.1",
 				"chalk": "4.1.2",
@@ -3388,29 +3397,29 @@
 			},
 			"dependencies": {
 				"debug": {
-					"version": "4.3.4",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-					"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+					"version": "4.3.5",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.5.tgz",
+					"integrity": "sha512-pt0bNEmneDIvdL1Xsd9oDQ/wrQRkXDT4AUWlNZNPKvW5x/jyO9VFXkJUP07vQ2upmw5PlaITaPKc31jK13V+jg==",
 					"requires": {
 						"ms": "2.1.2"
 					}
 				},
 				"engine.io-client": {
-					"version": "6.4.0",
-					"resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.4.0.tgz",
-					"integrity": "sha512-GyKPDyoEha+XZ7iEqam49vz6auPnNJ9ZBfy89f+rMMas8AuiMWOZ9PVzu8xb9ZC6rafUqiGHSCfu22ih66E+1g==",
+					"version": "6.5.4",
+					"resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.5.4.tgz",
+					"integrity": "sha512-GeZeeRjpD2qf49cZQ0Wvh/8NJNfeXkXXcoGh+F77oEAgo9gUHwT1fCRxSNU+YEEaysOJTnsFHmM5oAcPy4ntvQ==",
 					"requires": {
 						"@socket.io/component-emitter": "~3.1.0",
 						"debug": "~4.3.1",
-						"engine.io-parser": "~5.0.3",
-						"ws": "~8.11.0",
+						"engine.io-parser": "~5.2.1",
+						"ws": "~8.17.1",
 						"xmlhttprequest-ssl": "~2.0.0"
 					}
 				},
 				"engine.io-parser": {
-					"version": "5.0.6",
-					"resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.0.6.tgz",
-					"integrity": "sha512-tjuoZDMAdEhVnSFleYPCtdL2GXwVTGtNjoeJd9IhIG3C1xs9uwxqRNEu5WpnDZCaozwVlK/nuQhpodhXSIMaxw=="
+					"version": "5.2.2",
+					"resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.2.tgz",
+					"integrity": "sha512-RcyUFKA93/CXH20l4SoVvzZfrSDMOTUS3bWVpTt2FuFP+XYrL8i8oonHP7WInRyVHXh0n/ORtoeiE1os+8qkSw=="
 				},
 				"ms": {
 					"version": "2.1.2",
@@ -3418,20 +3427,20 @@
 					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
 				},
 				"socket.io-client": {
-					"version": "4.6.1",
-					"resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.6.1.tgz",
-					"integrity": "sha512-5UswCV6hpaRsNg5kkEHVcbBIXEYoVbMQaHJBXJCyEQ+CiFPV1NIOY0XOFWG4XR4GZcB8Kn6AsRs/9cy9TbqVMQ==",
+					"version": "4.7.5",
+					"resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.7.5.tgz",
+					"integrity": "sha512-sJ/tqHOCe7Z50JCBCXrsY3I2k03iOiUe+tj1OmKeD2lXPiGH/RUCdTZFoqVyN7l1MnpIzPrGtLcijffmeouNlQ==",
 					"requires": {
 						"@socket.io/component-emitter": "~3.1.0",
 						"debug": "~4.3.2",
-						"engine.io-client": "~6.4.0",
-						"socket.io-parser": "~4.2.1"
+						"engine.io-client": "~6.5.2",
+						"socket.io-parser": "~4.2.4"
 					}
 				},
 				"ws": {
-					"version": "8.11.0",
-					"resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
-					"integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
+					"version": "8.17.1",
+					"resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
+					"integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
 					"requires": {}
 				},
 				"xmlhttprequest-ssl": {
@@ -3749,9 +3758,9 @@
 			"integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
 		},
 		"engine.io": {
-			"version": "6.4.2",
-			"resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.4.2.tgz",
-			"integrity": "sha512-FKn/3oMiJjrOEOeUub2WCox6JhxBXq/Zn3fZOMCBxKnNYtsdKjxhl7yR3fZhM9PV+rdE75SU5SYMc+2PGzo+Tg==",
+			"version": "6.5.5",
+			"resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.5.5.tgz",
+			"integrity": "sha512-C5Pn8Wk+1vKBoHghJODM63yk8MvrO9EWZUfkAt5HAqIgPE4/8FF0PEGHXtEd40l223+cE5ABWuPzm38PHFXfMA==",
 			"requires": {
 				"@types/cookie": "^0.4.1",
 				"@types/cors": "^2.8.12",
@@ -3761,27 +3770,30 @@
 				"cookie": "~0.4.1",
 				"cors": "~2.8.5",
 				"debug": "~4.3.1",
-				"engine.io-parser": "~5.0.3",
-				"ws": "~8.11.0"
+				"engine.io-parser": "~5.2.1",
+				"ws": "~8.17.1"
 			},
 			"dependencies": {
 				"@types/node": {
-					"version": "18.16.3",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-18.16.3.tgz",
-					"integrity": "sha512-OPs5WnnT1xkCBiuQrZA4+YAV4HEJejmHneyraIaxsbev5yCEr6KMwINNFP9wQeFIw8FWcoTqF3vQsa5CDaI+8Q=="
+					"version": "20.14.6",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.6.tgz",
+					"integrity": "sha512-JbA0XIJPL1IiNnU7PFxDXyfAwcwVVrOoqyzzyQTyMeVhBzkJVMSkC1LlVsRQ2lpqiY4n6Bb9oCS6lzDKVQxbZw==",
+					"requires": {
+						"undici-types": "~5.26.4"
+					}
 				},
 				"debug": {
-					"version": "4.3.4",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-					"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+					"version": "4.3.5",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.5.tgz",
+					"integrity": "sha512-pt0bNEmneDIvdL1Xsd9oDQ/wrQRkXDT4AUWlNZNPKvW5x/jyO9VFXkJUP07vQ2upmw5PlaITaPKc31jK13V+jg==",
 					"requires": {
 						"ms": "2.1.2"
 					}
 				},
 				"engine.io-parser": {
-					"version": "5.0.6",
-					"resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.0.6.tgz",
-					"integrity": "sha512-tjuoZDMAdEhVnSFleYPCtdL2GXwVTGtNjoeJd9IhIG3C1xs9uwxqRNEu5WpnDZCaozwVlK/nuQhpodhXSIMaxw=="
+					"version": "5.2.2",
+					"resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.2.tgz",
+					"integrity": "sha512-RcyUFKA93/CXH20l4SoVvzZfrSDMOTUS3bWVpTt2FuFP+XYrL8i8oonHP7WInRyVHXh0n/ORtoeiE1os+8qkSw=="
 				},
 				"ms": {
 					"version": "2.1.2",
@@ -3789,9 +3801,9 @@
 					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
 				},
 				"ws": {
-					"version": "8.11.0",
-					"resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
-					"integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
+					"version": "8.17.1",
+					"resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
+					"integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
 					"requires": {}
 				}
 			}
@@ -5001,16 +5013,17 @@
 			}
 		},
 		"socket.io": {
-			"version": "4.6.1",
-			"resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.6.1.tgz",
-			"integrity": "sha512-KMcaAi4l/8+xEjkRICl6ak8ySoxsYG+gG6/XfRCPJPQ/haCRIJBTL4wIl8YCsmtaBovcAXGLOShyVWQ/FG8GZA==",
+			"version": "4.7.5",
+			"resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.7.5.tgz",
+			"integrity": "sha512-DmeAkF6cwM9jSfmp6Dr/5/mfMwb5Z5qRrSXLpo3Fq5SqyU8CMF15jIN4ZhfSwu35ksM1qmHZDQ/DK5XTccSTvA==",
 			"requires": {
 				"accepts": "~1.3.4",
 				"base64id": "~2.0.0",
+				"cors": "~2.8.5",
 				"debug": "~4.3.2",
-				"engine.io": "~6.4.1",
+				"engine.io": "~6.5.2",
 				"socket.io-adapter": "~2.5.2",
-				"socket.io-parser": "~4.2.1"
+				"socket.io-parser": "~4.2.4"
 			},
 			"dependencies": {
 				"debug": {
@@ -5301,6 +5314,11 @@
 			"version": "1.0.33",
 			"resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-1.0.33.tgz",
 			"integrity": "sha512-RqshF7TPTE0XLYAqmjlu5cLLuGdKrNu9O1KLA/qp39QtbZwuzwv1dT46DZSopoUMsYgXpB3Cv8a03FI8b74oFQ=="
+		},
+		"undici-types": {
+			"version": "5.26.5",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+			"integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
 		},
 		"universalify": {
 			"version": "0.1.2",

--- a/packages/browser-sync/package.json
+++ b/packages/browser-sync/package.json
@@ -60,7 +60,7 @@
 		"serve-index": "1.9.1",
 		"serve-static": "1.13.2",
 		"server-destroy": "1.0.1",
-		"socket.io": "^4.4.1",
+		"socket.io": "^4.7.5",
 		"ua-parser-js": "^1.0.33",
 		"yargs": "^17.3.1"
 	},


### PR DESCRIPTION
> Security alert triggered on our project highlighted the following issue.

> The latest possible version of socket.io that can be installed is 4.4.1. The earliest fixed version is 4.6.2.

# Impact

A specially crafted Socket.IO packet can trigger an uncaught exception on the Socket.IO server, thus killing the Node.js process.

```
node:events:502
    throw err; // Unhandled 'error' event
    ^

Error [ERR_UNHANDLED_ERROR]: Unhandled error. (undefined)
    at new NodeError (node:internal/errors:405:5)
    at Socket.emit (node:events:500:17)
    at /myapp/node_modules/socket.io/lib/socket.js:531:14
    at process.processTicksAndRejections (node:internal/process/task_queues:77:11) {
  code: 'ERR_UNHANDLED_ERROR',
  context: undefined
}
```
# References
- [socketio/socket.io@15af22f](https://github.com/socketio/socket.io/commit/15af22fc22bc6030fcead322c106f07640336115)
- [socketio/socket.io@d30630b](https://github.com/socketio/socket.io/commit/d30630ba10562bf987f4d2b42440fc41a828119c)