### PR TITLE
chore: updated notify types to match from IBrowserSyncOptions

### DIFF
--- a/packages/browser-sync-client/lib/types.ts
+++ b/packages/browser-sync-client/lib/types.ts
@@ -20,7 +20,7 @@ export interface InitOptions {
     codeSync: boolean;
     watchEvents: string[];
     browser: string;
-    notify: boolean;
+    notify: boolean | { styles: {[index: string]: string} | string[]};
     open: boolean;
     reloadDelay: number;
     minify: boolean;


### PR DESCRIPTION
I was using BrowserSync within a different package and noticed that the types for the `notify` indicate that it's only a boolean:

![Screenshot 2024-11-12 at 10 02 56 AM](https://github.com/user-attachments/assets/7be48a1c-8fa2-4c39-bc84-cf214b1e8cd5)

But it looks like the `IBrowserSyncOptions` interface has the [notify key](https://github.com/BrowserSync/browser-sync/blob/135982106b0df9e862f63d6a8e81424c495fffba/packages/browser-sync-client/lib/types/types.d.ts#L28) accepting a CSS styles object or array of CSS style rules.

I'm not as familiar with this project, so I just copied the type definition, but when I run a diff between the `InitOptions` and `IBrowserSyncOptions`, it looks like they're mostly the same except for `InitOptions` having:

```
    userPlugins: any[];
    session: number;
```

![Screenshot 2024-11-12 at 11 18 58 AM](https://github.com/user-attachments/assets/5986b2f7-e51a-49d7-886f-8ad7238921e4)

Should the types between these two things the same, or should we consider importing and extending `IBrowserSyncOptions`?