### PR TITLE
feat: replace eazy-logger with eazy-consola

### DIFF
--- a/packages/browser-sync/lib/index.js
+++ b/packages/browser-sync/lib/index.js
@@ -10,7 +10,7 @@ var publicUtils = require("./public/public-utils");
 var events = require("events");
 var chalk  = require("chalk");
 var PassThrough = require("stream").PassThrough;
-var logger = require("eazy-logger").Logger({
+var logger = require("eazy-consola").Logger({
     useLevelPrefixes: true
 });
 

--- a/packages/browser-sync/lib/logger.js
+++ b/packages/browser-sync/lib/logger.js
@@ -7,7 +7,7 @@ var chalk = require("chalk");
 
 var template = (prefix) => "[" + chalk.blue(prefix) + "] "
 
-var logger = require("eazy-logger").Logger({
+var logger = require("eazy-consola").Logger({
     useLevelPrefixes: false
 });
 

--- a/packages/browser-sync/package-lock.json
+++ b/packages/browser-sync/package-lock.json
@@ -18,7 +18,7 @@
 				"connect-history-api-fallback": "^1",
 				"dev-ip": "^1.0.1",
 				"easy-extender": "^2.3.4",
-				"eazy-logger": "^4.0.1",
+				"eazy-consola": "^1.0.0",
 				"etag": "^1.8.1",
 				"fresh": "^0.5.2",
 				"fs-extra": "3.0.1",
@@ -64,6 +64,22 @@
 			},
 			"engines": {
 				"node": ">= 8.0.0"
+			}
+		},
+		"../../../eazy-consola": {
+			"version": "1.0.0",
+			"license": "ISC",
+			"dependencies": {
+				"chalk": "^4.1.2",
+				"consola": "^3.4.2",
+				"defu": "^6.1.4"
+			},
+			"devDependencies": {
+				"@knighted/duel": "^2.0.0",
+				"rimraf": "^6.0.1",
+				"strip-ansi": "^7.1.0",
+				"typescript": "^5.8.2",
+				"vitest": "^0.34.6"
 			}
 		},
 		"node_modules/@socket.io/component-emitter": {
@@ -333,10 +349,9 @@
 			"dev": true
 		},
 		"node_modules/browser-sync-client": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/browser-sync-client/-/browser-sync-client-3.0.2.tgz",
-			"integrity": "sha512-tBWdfn9L0wd2Pjuz/NWHtNEKthVb1Y67vg8/qyGNtCqetNz5lkDkFnrsx5UhPNPYUO8vci50IWC/BhYaQskDiQ==",
-			"license": "ISC",
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/browser-sync-client/-/browser-sync-client-3.0.3.tgz",
+			"integrity": "sha512-TOEXaMgYNjBYIcmX5zDlOdjEqCeCN/d7opf/fuyUD/hhGVCfP54iQIDhENCi012AqzYZm3BvuFl57vbwSTwkSQ==",
 			"dependencies": {
 				"etag": "1.8.1",
 				"fresh": "0.5.2",
@@ -347,10 +362,9 @@
 			}
 		},
 		"node_modules/browser-sync-ui": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/browser-sync-ui/-/browser-sync-ui-3.0.2.tgz",
-			"integrity": "sha512-V3FwWAI+abVbFLTyJjXJlCMBwjc3GXf/BPGfwO2fMFACWbIGW9/4SrBOFYEOOtqzCjQE0Di+U3VIb7eES4omNA==",
-			"license": "Apache-2.0",
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/browser-sync-ui/-/browser-sync-ui-3.0.3.tgz",
+			"integrity": "sha512-FcGWo5lP5VodPY6O/f4pXQy5FFh4JK0f2/fTBsp0Lx1NtyBWs/IfPPJbW8m1ujTW/2r07oUXKTF2LYZlCZktjw==",
 			"dependencies": {
 				"async-each-series": "0.1.1",
 				"chalk": "4.1.2",
@@ -798,16 +812,9 @@
 				"node": ">= 4.0.0"
 			}
 		},
-		"node_modules/eazy-logger": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/eazy-logger/-/eazy-logger-4.0.1.tgz",
-			"integrity": "sha512-2GSFtnnC6U4IEKhEI7+PvdxrmjJ04mdsj3wHZTFiw0tUtG4HCWzTr13ZYTk8XOGnA1xQMaDljoBOYlk3D/MMSw==",
-			"dependencies": {
-				"chalk": "4.1.2"
-			},
-			"engines": {
-				"node": ">= 0.8.0"
-			}
+		"node_modules/eazy-consola": {
+			"resolved": "../../../eazy-consola",
+			"link": true
 		},
 		"node_modules/ecc-jsbn": {
 			"version": "0.1.2",
@@ -3439,9 +3446,9 @@
 			"dev": true
 		},
 		"browser-sync-client": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/browser-sync-client/-/browser-sync-client-3.0.2.tgz",
-			"integrity": "sha512-tBWdfn9L0wd2Pjuz/NWHtNEKthVb1Y67vg8/qyGNtCqetNz5lkDkFnrsx5UhPNPYUO8vci50IWC/BhYaQskDiQ==",
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/browser-sync-client/-/browser-sync-client-3.0.3.tgz",
+			"integrity": "sha512-TOEXaMgYNjBYIcmX5zDlOdjEqCeCN/d7opf/fuyUD/hhGVCfP54iQIDhENCi012AqzYZm3BvuFl57vbwSTwkSQ==",
 			"requires": {
 				"etag": "1.8.1",
 				"fresh": "0.5.2",
@@ -3449,9 +3456,9 @@
 			}
 		},
 		"browser-sync-ui": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/browser-sync-ui/-/browser-sync-ui-3.0.2.tgz",
-			"integrity": "sha512-V3FwWAI+abVbFLTyJjXJlCMBwjc3GXf/BPGfwO2fMFACWbIGW9/4SrBOFYEOOtqzCjQE0Di+U3VIb7eES4omNA==",
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/browser-sync-ui/-/browser-sync-ui-3.0.3.tgz",
+			"integrity": "sha512-FcGWo5lP5VodPY6O/f4pXQy5FFh4JK0f2/fTBsp0Lx1NtyBWs/IfPPJbW8m1ujTW/2r07oUXKTF2LYZlCZktjw==",
 			"requires": {
 				"async-each-series": "0.1.1",
 				"chalk": "4.1.2",
@@ -3789,12 +3796,17 @@
 				"lodash": "^4.17.10"
 			}
 		},
-		"eazy-logger": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/eazy-logger/-/eazy-logger-4.0.1.tgz",
-			"integrity": "sha512-2GSFtnnC6U4IEKhEI7+PvdxrmjJ04mdsj3wHZTFiw0tUtG4HCWzTr13ZYTk8XOGnA1xQMaDljoBOYlk3D/MMSw==",
+		"eazy-consola": {
+			"version": "file:../../../eazy-consola",
 			"requires": {
-				"chalk": "4.1.2"
+				"@knighted/duel": "^2.0.0",
+				"chalk": "^4.1.2",
+				"consola": "^3.4.2",
+				"defu": "^6.1.4",
+				"rimraf": "^6.0.1",
+				"strip-ansi": "^7.1.0",
+				"typescript": "^5.8.2",
+				"vitest": "^0.34.6"
 			}
 		},
 		"ecc-jsbn": {

--- a/packages/browser-sync/package.json
+++ b/packages/browser-sync/package.json
@@ -44,7 +44,7 @@
 		"connect-history-api-fallback": "^1",
 		"dev-ip": "^1.0.1",
 		"easy-extender": "^2.3.4",
-		"eazy-logger": "^4.0.1",
+		"eazy-consola": "^1.0.0",
 		"etag": "^1.8.1",
 		"fresh": "^0.5.2",
 		"fs-extra": "3.0.1",

--- a/packages/browser-sync/test/protractor/logger.js
+++ b/packages/browser-sync/test/protractor/logger.js
@@ -1,5 +1,5 @@
 var chalk       = require("chalk");
-module.exports = require("eazy-logger").Logger({
+module.exports = require("eazy-consola").Logger({
     prefix: chalk.magenta("[BS E2E] "),
     useLevelPrefixes: true,
     custom: {

--- a/packages/browser-sync/test/specs/cli/cli.exec.js
+++ b/packages/browser-sync/test/specs/cli/cli.exec.js
@@ -1,21 +1,25 @@
-describe("CLI: exec", function() {
+describe.only("CLI: exec", function() {
     this.timeout(10000);
     it("Can launch from cli", function(done) {
         var strem = require("child_process").spawn("node", [
             require.resolve("../../../dist/bin"),
             "start"
         ]);
-        var chunks = [];
+        let timer;
+        let chunks = [];
         strem.stdout.on("data", function(data) {
             chunks.push(data.toString());
             if (chunks.join("").indexOf("Copy the following snippet") > -1) {
                 strem.kill("SIGINT");
-            } else {
-                done(new Error("missing output"))
+                clearTimeout(timer);
             }
         });
         strem.on("close", function() {
             done();
         });
+
+        timer = setTimeout(() => {
+            done(new Error("missing output"));
+        }, 1000);
     });
 });


### PR DESCRIPTION
I've created a [new package](https://www.npmjs.com/package/eazy-consola) just to fix the vulnerability https://github.com/advisories/GHSA-r7jx-5m6m-cpg9